### PR TITLE
feat: 비밀번호 입력란에 마스킹 토글 기능 추가

### DIFF
--- a/app/admin/signup/page.tsx
+++ b/app/admin/signup/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { signup } from "@/app/admin/login/actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,8 +12,13 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import Link from "next/link";
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
 
 export default function SignupPage() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <Card className="w-[400px]">
@@ -51,18 +58,49 @@ export default function SignupPage() {
               <label htmlFor="password" className="text-sm font-medium">
                 비밀번호
               </label>
-              <Input id="password" name="password" type="password" required />
+              <div className="relative">
+                <Input
+                  id="password"
+                  name="password"
+                  type={showPassword ? "text" : "password"}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                >
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
             </div>
             <div className="space-y-2">
               <label htmlFor="confirmPassword" className="text-sm font-medium">
                 비밀번호 확인
               </label>
-              <Input
-                id="confirmPassword"
-                name="confirmPassword"
-                type="password"
-                required
-              />
+              <div className="relative">
+                <Input
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  type={showConfirmPassword ? "text" : "password"}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                >
+                  {showConfirmPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
             </div>
           </CardContent>
           <CardFooter className="flex flex-col space-y-2">

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -41,8 +41,9 @@ export async function updateSession(request: NextRequest) {
 
   if (
     !user &&
+    request.nextUrl.pathname.startsWith("/admin") &&
     !request.nextUrl.pathname.startsWith("/admin/login") &&
-    !request.nextUrl.pathname.startsWith("/admin/auth")
+    !request.nextUrl.pathname.startsWith("/admin/signup")
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 어드민 페이지 회원가입의 경우 비밀번호 입력란에 마스킹 토글 기능을 추가했습니다.  
사용자가 눈 아이콘을 클릭하면 비밀번호가 보이도록 구현하여 UX를 개선했습니다.


### 스크린샷 (선택)
<img width="321" alt="스크린샷 2025-05-22 오후 1 17 48" src="https://github.com/user-attachments/assets/8e6fdfec-45d5-4fc0-9c3d-d1de749e07c5" />


## 💬리뷰 요구사항(선택)

> 
