### PR TITLE
Feat/dev/apis

### DIFF
--- a/apis/supabase.ts
+++ b/apis/supabase.ts
@@ -5,7 +5,9 @@ const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
 
 export const supabase = createBrowserClient(supabaseUrl, supabaseKey);
 
-const {
-  data: { session },
-} = await supabase.auth.getSession();
-console.log(session);
+export async function getSession() {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  return session;
+}

--- a/lib/data/students-data.ts
+++ b/lib/data/students-data.ts
@@ -3,6 +3,7 @@ export interface Student {
   name: string;
   email: string;
   phone: string;
+  challenges?: string[];
 }
 
 // 메모리 내 학생 데이터 (실제로는 데이터베이스를 사용해야 함)


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - `getUserChallenges(userId)` API 함수 추가  
  → `ChallengeUsers` 테이블에서 유저가 연동된 챌린지 목록 조회
  → 내부적으로 `Challenges` 테이블과 조인하여 챌린지 정보(`id`, `name`) 반환
> - 수강생 추가/수정/삭제 시, 챌린지 연동 정보(`ChallengeUsers` 테이블)도 함께 업데이트되도록 로직 수정
>   - 수강생 추가 시: 선택된 챌린지에 연동 정보 생성
>   - 수강생 수정 시: 챌린지 연동 정보 업데이트
>   - 수강생 삭제 시: 관련 챌린지 연동 정보도 함께 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
