### PR TITLE
feat: 챌린지 별 수강생 목록 조회 API 함수 추가

### DIFF
--- a/apis/users.ts
+++ b/apis/users.ts
@@ -206,3 +206,34 @@ export async function getUserChallenges(userId: string): Promise<Challenge[]> {
     return [];
   }
 }
+
+export async function getChallengeUsers(
+  challengeId: string,
+): Promise<UserData[]> {
+  try {
+    const { data, error } = await supabase
+      .from("ChallengeUsers")
+      .select(
+        `
+        user_id,
+        Users (
+          id,
+          name,
+          email
+        )
+      `,
+      )
+      .eq("challenge_id", challengeId);
+
+    if (error) throw error;
+
+    return data.map((item: any) => ({
+      id: item.Users.id,
+      name: item.Users.name,
+      email: item.Users.email,
+    }));
+  } catch (error) {
+    console.error("챌린지 수강생 정보 조회 실패", error);
+    return [];
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - 특정 챌린지에 속한 수강생 정보를 조회하는 getChallengeUsers 함수 추가
> Supabase의 ChallengeUsers 테이블과 Users 테이블을 조인하여 사용자 id, 이름, 이메일 정보를 반환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
