### PR TITLE
feat: 사용자 페이지 관련 api 함수 추가

### DIFF
--- a/apis/assignments.ts
+++ b/apis/assignments.ts
@@ -1,0 +1,22 @@
+import { supabase } from "./supabase";
+
+export async function getAssignment(lectureId: string) {
+  try {
+    const { data: assignments, error } = await supabase
+      .from("Assignments")
+      .select("*")
+      .eq("lecture_id", lectureId)
+      .order("created_at", { ascending: true });
+
+    if (error) throw error;
+
+    return assignments || [];
+  } catch (error) {
+    console.error("과제 데이터 조회 실패:", error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : "강의 과제 목록 조회 중 오류가 발생했습니다.",
+    );
+  }
+}

--- a/apis/assignments.ts
+++ b/apis/assignments.ts
@@ -2,7 +2,7 @@ import { supabase } from "./supabase";
 
 export async function getAssignment(lectureId: string) {
   try {
-    const { data: assignments, error } = await supabase
+    const { data: assignment, error } = await supabase
       .from("Assignments")
       .select("*")
       .eq("lecture_id", lectureId)
@@ -10,13 +10,13 @@ export async function getAssignment(lectureId: string) {
 
     if (error) throw error;
 
-    return assignments || [];
+    return assignment || [];
   } catch (error) {
     console.error("과제 데이터 조회 실패:", error);
     throw new Error(
       error instanceof Error
         ? error.message
-        : "강의 과제 목록 조회 중 오류가 발생했습니다.",
+        : "강의 과제 데이터 조회 중 오류가 발생했습니다.",
     );
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

> - 사용자 페이지에서 사용할 수 있도록 다음과 같은 Supabase API 함수 두 가지를 작성했습니다.
> ### 1. `getUserLectures(userId: string)`
> - 사용자가 속한 챌린지 ID 목록을 `ChallengeUsers` 테이블에서 조회
> - 해당 챌린지들과 연결된 강의 정보를 `ChallengeLectures` 및 `Lectures` 조인으로 조회
> - 각 강의의 `open_at`, `challenge_id` 정보를 포함해 반환
>
>### 2. `getAssignment(lectureId: string)`
> - 특정 강의에 대한 과제 데이터를 `Assignments` 테이블에서 조회


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
