### PR TITLE
feat: 챌린지 별 강의 과제 제출 통계 조회 API 추가

### DIFF
--- a/apis/assignments.ts
+++ b/apis/assignments.ts
@@ -1,5 +1,14 @@
 import { supabase } from "./supabase";
 
+interface ChallengeLecture {
+  id: string;
+  lecture_id: string;
+  Lectures: {
+    id: string;
+    name: string;
+  };
+}
+
 export async function getAssignment(lectureId: string) {
   try {
     const { data: assignment, error } = await supabase
@@ -56,6 +65,86 @@ export async function createSubmission({
       error instanceof Error
         ? error.message
         : "과제 제출 중 오류가 발생했습니다.",
+    );
+  }
+}
+
+// 챌린지 별 각 강의 과제 통계를 계산하는 함수
+export async function getAssignmentStats(challengeId: string) {
+  try {
+    // 1. ChallengeLectures 테이블에서 challenge_id로 데이터 조회
+    const { data: challengeLectures, error: challengeError } = (await supabase
+      .from("ChallengeLectures")
+      .select(
+        `
+        id,
+        lecture_id,
+        Lectures!inner (
+          id,
+          name
+        )
+      `,
+      )
+      .eq("challenge_id", challengeId)) as {
+      data: ChallengeLecture[] | null;
+      error: any;
+    };
+
+    if (challengeError) throw challengeError;
+
+    // 2. 챌린지의 전체 참여자 수 조회
+    const { data: challengeUsers, error: usersError } = await supabase
+      .from("ChallengeUsers")
+      .select("user_id")
+      .eq("challenge_id", challengeId);
+
+    if (usersError) throw usersError;
+    const totalParticipants = challengeUsers.length;
+
+    // 3. 각 강의별 제출 현황과 과제 정보 조회
+    const submissionRates = await Promise.all(
+      challengeLectures.map(async (lecture) => {
+        // 과제 정보 조회
+        const { data: assignment, error: assignmentError } = await supabase
+          .from("Assignments")
+          .select("title")
+          .eq("lecture_id", lecture.lecture_id)
+          .single();
+
+        if (assignmentError) throw assignmentError;
+
+        // 제출 현황 조회
+        const { data: submissions, error: submissionError } = await supabase
+          .from("Submissions")
+          .select("user_id")
+          .eq("challenge_lecture_id", lecture.id);
+
+        if (submissionError) throw submissionError;
+
+        const submittedCount = submissions.length;
+        const submissionRate =
+          totalParticipants > 0
+            ? Math.round((submittedCount / totalParticipants) * 100)
+            : 0;
+
+        return {
+          lectureId: lecture.lecture_id,
+          lectureName: lecture.Lectures.name,
+          totalParticipants,
+          submittedCount,
+          submissionRate,
+          assignmentTitle: assignment?.title || "",
+        };
+      }),
+    );
+
+    return submissionRates;
+  } catch (error) {
+    console.error("과제 제출률 계산 실패:", error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : "과제 제출률 계산 중 오류가 발생했습니다.",
     );
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - 챌린지 id를 기준으로 해당 챌린지에 속한 모든 강의의 과제 제출 통계를 조회하는 API 함수입니다.
- 각 강의별로 아래 정보를 반환합니다:
  - 강의 ID 및 이름
  - 과제 제목
  - 챌린지 참여자 수
  - 과제 제출한 인원 수
  - 제출률 (백분율)

### 스크린샷 (선택)
해당 함수를 호출하면 다음과 같은 데이터들 조회가능합니다.
<img width="508" alt="스크린샷 2025-05-29 오후 2 53 03" src="https://github.com/user-attachments/assets/4f6e051d-31d5-47a1-a6d0-5542ebdcac69" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
