### PR TITLE
fix: getUserLectures 함수 마감일 날짜 체크 로직 수정

### DIFF
--- a/apis/lectures.ts
+++ b/apis/lectures.ts
@@ -581,7 +581,7 @@ export async function getUserLectures(userId: number) {
     console.log("챌린지 데이터:", JSON.stringify(challengeData, null, 2));
 
     // 현재 날짜
-    const currentDate = new Date();
+    const currentDate = new Date(new Date().setHours(0, 0, 0, 0));
 
     // 2. 현재 진행 중인 챌린지 ID만 필터링
     const activeChallengeIds = (challengeData as unknown as ChallengeUser[])
@@ -592,7 +592,7 @@ export async function getUserLectures(userId: number) {
         }
         const openDate = new Date(challenge.Challenges.open_date);
         const closeDate = new Date(challenge.Challenges.close_date);
-        return currentDate >= openDate && currentDate < closeDate;
+        return currentDate >= openDate && currentDate <= closeDate;
       })
       .map((challenge) => challenge.challenge_id);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - getUserLectures 함수 마감일 날짜 체크 로직 수정했습니다.
> 기존에는 currentDate가 시간까지 포함된 Date 객체였습니다. 하지만 Supabase의 open_date, close_date는 date 타입이라 시간 정보 없이 자정(00:00:00) 으로 처리됩니다. 이로 인해 의도치 않게 마감일 당일에도 강의가 닫힌 것으로 처리되는 문제 발생하여 currentDate를 날짜만 비교하도록 수정하여 로직 정상화했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> @wynter24 확인부탁드립니다!
