### PR TITLE
fix: getUserLectures 함수의 활성화된 챌린지 필터링 로직 개선

### DIFF
--- a/apis/lectures.ts
+++ b/apis/lectures.ts
@@ -689,8 +689,7 @@ export async function getUserLectures(userId: number) {
 
     console.log("챌린지 데이터:", JSON.stringify(challengeData, null, 2));
 
-    // 현재 날짜
-    const currentDate = new Date(new Date().setHours(0, 0, 0, 0));
+    const currentDate = new Date().toISOString().split("T")[0]; // 'YYYY-MM-DD' 형식으로 변환
 
     // 2. 현재 진행 중인 챌린지 ID만 필터링
     const activeChallengeIds = (challengeData as unknown as ChallengeUser[])
@@ -699,8 +698,8 @@ export async function getUserLectures(userId: number) {
           console.log("챌린지 데이터가 없습니다:", challenge);
           return false;
         }
-        const openDate = new Date(challenge.Challenges.open_date);
-        const closeDate = new Date(challenge.Challenges.close_date);
+        const openDate = challenge.Challenges.open_date;
+        const closeDate = challenge.Challenges.close_date;
         return currentDate >= openDate && currentDate <= closeDate;
       })
       .map((challenge) => challenge.challenge_id);


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - getUserLectures 함수의 활성화된 챌린지 필터링 로직에서 날짜 비교 시 시간 정보 제거하여 순수 날짜 비교로 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
