### PR TITLE
fix: 직접 업로드 한 영상 재생되지 않는 문제 해결

### DIFF
--- a/components/daily-lecture/lecture-player.tsx
+++ b/components/daily-lecture/lecture-player.tsx
@@ -52,12 +52,21 @@ export default function LecturePlayer({
       <div className="relative aspect-video w-full bg-black">
         {isPlaying ? (
           <div className="relative h-full w-full">
-            <iframe
-              src={`${getYouTubeEmbedUrl(lectureUrl)}?autoplay=1`}
-              className="absolute inset-0 w-full h-full"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowFullScreen
-            />
+            {upload_type === 0 ? (
+              <iframe
+                src={`${getYouTubeEmbedUrl(lectureUrl)}?autoplay=1`}
+                className="absolute inset-0 w-full h-full"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            ) : (
+              <video
+                src={lectureUrl}
+                className="absolute inset-0 w-full h-full"
+                autoPlay
+                controls
+              />
+            )}
             <Button
               variant="outline"
               size="icon"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81

## 📝작업 내용

> 직접 업로드한 영상 재생되지 않는 문제 해결

## 💬리뷰 요구사항

직접 업로드한 영상의 경우, youtube와 달리 재생 및 정지 동작 시 각 아이콘이 보이고 사라지는 효과가 없어 어색함이 있을 수 있습니다.
이를 보완하기 위해 유사한 동작을 추가하려 했으나 잘 적용이 되지 않아 추후 리팩토링 때 개선하겠습니다!