### PR TITLE
feat: 제출된 과제 수정 기능 추가

### DIFF
--- a/apis/assignments.ts
+++ b/apis/assignments.ts
@@ -25,15 +25,11 @@ export async function getAssignment(lectureId: number) {
 }
 
 export async function createSubmission({
-  name,
-  email,
   link,
   text,
   challengeLectureId,
   userId,
 }: {
-  name: string;
-  email: string;
   link: string;
   text: string;
   challengeLectureId: number;

--- a/apis/assignments.ts
+++ b/apis/assignments.ts
@@ -70,16 +70,16 @@ export async function createSubmission({
         {
           user_id: userId,
           submitted_at: currentServerTime.toISOString(),
-            is_submit: true,
-            assignment_url: link,
-            assignment_comment: text,
-            challenge_lecture_id: challengeLectureId,
-          },
-        ])
-        .select();
+          is_submit: true,
+          assignment_url: link,
+          assignment_comment: text,
+          challenge_lecture_id: challengeLectureId,
+        },
+      ])
+      .select();
 
-      if (error) throw error;
-      return data;
+    if (error) throw error;
+    return data;
   } catch (error) {
     console.error("과제 제출 실패:", error);
     throw new Error(
@@ -172,7 +172,8 @@ export async function getAssignmentStats(challengeId: number) {
         )
       `,
       )
-      .eq("challenge_id", challengeId)) as {
+      .eq("challenge_id", challengeId)
+      .order("sequence", { ascending: true })) as {
       data: ChallengeLecture[] | null;
       error: any;
     };
@@ -252,7 +253,7 @@ export async function getUserSubmission({
       .maybeSingle();
 
     if (error) {
-      console.error("Supabase 조회 중 에러:", error);
+      // console.error("Supabase 조회 중 에러:", error);
       throw error;
     }
 

--- a/components/daily-assignment/assignment-submission-item.tsx
+++ b/components/daily-assignment/assignment-submission-item.tsx
@@ -5,50 +5,126 @@ import { userInfo } from "@/types/user";
 import { timeAgo } from "@/utils/date/timeAgo";
 import { SubmittedAssignment } from "@/types/assignment";
 import { getLinkIcon } from "@/utils/link/linkUtils";
+import { useState } from "react";
+import { updateSubmission } from "@/apis/assignments";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 interface AssignmentSubmissionItemProps {
   userInfo: userInfo;
   submittedAssignment: SubmittedAssignment | null;
+  isBeforeDeadline: boolean;
 }
 
 export function AssignmentSubmissionItem({
   userInfo,
   submittedAssignment,
+  isBeforeDeadline,
 }: AssignmentSubmissionItemProps) {
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedComment, setEditedComment] = useState(
+    submittedAssignment?.assignment_comment || "",
+  );
+  const [editedUrl, setEditedUrl] = useState(
+    submittedAssignment?.assignment_url || "",
+  );
+
+  const { mutate: handleSubmit } = useMutation({
+    mutationFn: (submissionId: number) =>
+      updateSubmission({
+        submissionId,
+        link: editedUrl,
+        text: editedComment,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          "submitted-assignment",
+          userInfo.id,
+          submittedAssignment.challenge_lecture_id,
+        ],
+      });
+      setIsEditing(false);
+      toast.success("과제가 성공적으로 수정되었습니다.");
+    },
+    onError: (error) => {
+      toast.error(error.message || "과제 수정에 실패했습니다.");
+    },
+  });
+
   return (
     <div className="bg-[#1C1F2B]/60 p-4 rounded-xl border border-gray-700/30 hover:border-gray-600/50 shadow-sm hover:shadow-md transition-all duration-300">
-      <div className="flex items-center mb-3">
-        <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#5046E4] to-[#8C7DFF] mr-3 flex items-center justify-center text-white font-bold shadow-md">
-          {userInfo.name.charAt(0)}
-        </div>
-        <div>
-          <p className="text-sm font-medium">{userInfo.name}</p>
-          <div className="flex items-center text-xs text-gray-400 mt-0.5">
-            <Clock className="h-3 w-3 mr-1" />
-            {timeAgo(submittedAssignment.submitted_at)}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center">
+          <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#5046E4] to-[#8C7DFF] mr-3 flex items-center justify-center text-white font-bold shadow-md">
+            {userInfo.name.charAt(0)}
+          </div>
+          <div>
+            <p className="text-sm font-medium">{userInfo.name}</p>
+            <div className="flex items-center text-xs text-gray-400 mt-0.5">
+              <Clock className="h-3 w-3 mr-1" />
+              {timeAgo(submittedAssignment.submitted_at)}
+            </div>
           </div>
         </div>
+        {isBeforeDeadline && (
+          <button
+            onClick={() => setIsEditing(!isEditing)}
+            className="text-sm text-[#8C7DFF] hover:text-[#A99AFF]"
+          >
+            {isEditing ? "취소" : "수정"}
+          </button>
+        )}
       </div>
-      {submittedAssignment.assignment_comment && (
-        <p className="text-sm mb-3 text-gray-200 leading-relaxed">
-          {submittedAssignment.assignment_comment}
-        </p>
-      )}
-      {submittedAssignment.assignment_url && (
-        <a
-          href={submittedAssignment.assignment_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 text-[#8C7DFF] hover:text-[#A99AFF] text-sm bg-[#1A1D29]/80 p-2.5 rounded-lg border border-gray-700/30 hover:border-[#5046E4]/30 max-w-full overflow-hidden transition-all duration-300 group"
-        >
-          <span className="bg-[#5046E4]/10 text-[#8C7DFF] text-xs px-2 py-1 rounded-md font-medium flex-shrink-0">
-            {getLinkIcon(submittedAssignment.assignment_url)}
-          </span>
-          <span className="truncate overflow-ellipsis max-w-[calc(100%-80px)]">
-            {submittedAssignment.assignment_url}
-          </span>
-          <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 ml-auto opacity-70 group-hover:opacity-100 transition-opacity" />
-        </a>
+
+      {isEditing ? (
+        <div className="space-y-3">
+          <textarea
+            value={editedComment}
+            onChange={(e) => setEditedComment(e.target.value)}
+            className="w-full p-2 rounded-lg bg-[#1A1D29]/80 border border-gray-700/30 text-sm text-gray-200"
+            placeholder="과제 코멘트를 입력하세요"
+            rows={3}
+          />
+          <input
+            type="url"
+            value={editedUrl}
+            onChange={(e) => setEditedUrl(e.target.value)}
+            className="w-full p-2 rounded-lg bg-[#1A1D29]/80 border border-gray-700/30 text-sm text-gray-200"
+            placeholder="과제 URL을 입력하세요"
+          />
+          <button
+            onClick={() => handleSubmit(submittedAssignment.id)}
+            className="w-full py-2 bg-[#5046E4] hover:bg-[#4338CA] text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            저장하기
+          </button>
+        </div>
+      ) : (
+        <>
+          {submittedAssignment.assignment_comment && (
+            <p className="text-sm mb-3 text-gray-200 leading-relaxed">
+              {submittedAssignment.assignment_comment}
+            </p>
+          )}
+          {submittedAssignment.assignment_url && (
+            <a
+              href={submittedAssignment.assignment_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 text-[#8C7DFF] hover:text-[#A99AFF] text-sm bg-[#1A1D29]/80 p-2.5 rounded-lg border border-gray-700/30 hover:border-[#5046E4]/30 max-w-full overflow-hidden transition-all duration-300 group"
+            >
+              <span className="bg-[#5046E4]/10 text-[#8C7DFF] text-xs px-2 py-1 rounded-md font-medium flex-shrink-0">
+                {getLinkIcon(submittedAssignment.assignment_url)}
+              </span>
+              <span className="truncate overflow-ellipsis max-w-[calc(100%-80px)]">
+                {submittedAssignment.assignment_url}
+              </span>
+              <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 ml-auto opacity-70 group-hover:opacity-100 transition-opacity" />
+            </a>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/daily-assignment/assignment-submission-section.tsx
+++ b/components/daily-assignment/assignment-submission-section.tsx
@@ -38,6 +38,13 @@ export function AssignmentSubmissionSection({
     getServerTime();
   }, []);
 
+  // 마감 기한이 지나지 않았는지 확인 (마감 기한 전에만 수정 가능) TODO: open_at이 아닌 due_at으로 변경할 지 논의 필
+  const isBeforeDeadline =
+    serverTime && open_at
+      ? new Date(serverTime) <=
+        new Date(new Date(open_at).getTime() + 24 * 60 * 60 * 1000)
+      : false;
+
   // 선택한 강의에 대한 과제 정보 가져오기
   const { data: assignmentInfo = [] } = useQuery({
     queryKey: ["assignment-info", lectureId],
@@ -130,6 +137,7 @@ export function AssignmentSubmissionSection({
             <AssignmentSubmissionItem
               userInfo={userInfo}
               submittedAssignment={submittedAssignment}
+              isBeforeDeadline={isBeforeDeadline}
             />
           ) : (
             <div className="text-gray-400 text-center py-6">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #89

## 📝작업 내용

> - 사용자 페이지에서 제출된 과제를 수정하는 기능 추가하였습니다.
> - 기존의 createSubmission 함수에 이미 수정 로직이 포함되어 있었는데 이를 분리하여 updateSubmission 함수를 추가했습니다.
> - 사용자 페이지의 경우 서버 시간과 비교하여 마감일이 지나면 수정 버튼이 사라지게 처리하였습니다.
> - 추가로 관리자 페이지의 대시보드에서 과제가 순서대로 보여지지 않는 불일치 문제가 있어 getAssignmentStats 함수 호출 시 강의를 sequence 순서대로 조회되게 수정하였습니다.

### 스크린샷 (선택)
- 마감일이 지나지 않은 경우(수정가능)
<img width="916" alt="스크린샷 2025-06-09 오후 2 27 29" src="https://github.com/user-attachments/assets/9efaace5-6feb-4663-a187-09ed087c8297" />

- 마감일이 지난 경우(수정 불가, 수정 버튼 숨김)
<img width="920" alt="스크린샷 2025-06-09 오후 2 28 00" src="https://github.com/user-attachments/assets/b7b64a18-518f-4308-8315-00d5346bfc1a" />

- 대시보드 수정 전(과제가 순서대로 조회되지 않음)
<img width="811" alt="스크린샷 2025-06-09 오후 2 34 14" src="https://github.com/user-attachments/assets/6601aefd-73c4-4439-beb3-8c702e194a25" />

- 수정 후(순서대로 조회)
<img width="745" alt="스크린샷 2025-06-09 오후 2 36 15" src="https://github.com/user-attachments/assets/e7ba6a41-3140-472a-8197-8b30a72b3164" />


## 💬리뷰 요구사항(선택)

> @wynter24 일단 제가 작업하는 김에 프론트단에 기능을 달아놨는데 편하게 수정 혹은 추가 작업해주시면 될 것 같습니다!
