### PR TITLE
fix: 유튜브 단축 url 처리하는 로직 추가

### DIFF
--- a/utils/youtube.ts
+++ b/utils/youtube.ts
@@ -1,7 +1,14 @@
-
-
 export const getYouTubeVideoId = (url: string) => {
   try {
+    // youtu.be 형식 처리
+    if (url.includes("youtu.be")) {
+      const parts = url.split("youtu.be/");
+      if (parts.length > 1) {
+        return parts[1].split("?")[0];
+      }
+    }
+
+    // watch?v= 형식 처리
     const parts = url.split("watch?v=");
     if (parts.length > 1) {
       const lastPart = parts[parts.length - 1];
@@ -37,5 +44,5 @@ export const getVideoThumbnailUrl = (upload_type: number, url: string) => {
 
 // URL에서 업로드 타입 (0: YouTube, 1: 직접 업로드)을 가져오는 함수
 export const getUploadTypeFromUrl = (url: string): number => {
-  return url.includes('youtube.com') ? 0 : 1;
+  return url.includes("youtube.com") || url.includes("youtu.be") ? 0 : 1;
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - 기존 유튜브 url 처리하는 함수에 단축 url도 처리하는 로직 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 추후 함수 정리가 필요할 것 같습니다. `getUploadTypeFromUrl`의 경우 url로 업로드타입을 지정하는 함수인데 사실 Lecture 데이터의 upload_type을 가져오면 돼서 제가 보기엔 필요없는 함수같은데 커서가 자동으로 코드를 생성해주다 보니 검수가 안된 것 같네요. 나중에 정리하도록 하겠습니다! @wynter24 @dohyeons 
