### PR TITLE
fix: 사용자 페이지 제출된 과제 수정 버튼 활성화 로직 수정

### DIFF
--- a/components/daily-assignment/assignment-submission-item.tsx
+++ b/components/daily-assignment/assignment-submission-item.tsx
@@ -13,13 +13,13 @@ import { toast } from "sonner";
 interface AssignmentSubmissionItemProps {
   userInfo: userInfo;
   submittedAssignment: SubmittedAssignment | null;
-  isBeforeDeadline: boolean;
+  isTodayLecture: boolean;
 }
 
 export function AssignmentSubmissionItem({
   userInfo,
   submittedAssignment,
-  isBeforeDeadline,
+  isTodayLecture,
 }: AssignmentSubmissionItemProps) {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
@@ -68,7 +68,7 @@ export function AssignmentSubmissionItem({
             </div>
           </div>
         </div>
-        {isBeforeDeadline && (
+        {isTodayLecture && (
           <button
             onClick={() => setIsEditing(!isEditing)}
             className="text-sm text-[#8C7DFF] hover:text-[#A99AFF]"

--- a/components/daily-assignment/assignment-submission-section.tsx
+++ b/components/daily-assignment/assignment-submission-section.tsx
@@ -31,11 +31,6 @@ export function AssignmentSubmissionSection({
     checkTodayLecture();
   }, [open_at]);
 
-  // 마감 기한이 지나지 않았는지 확인 (마감 기한 전에만 수정 가능) TODO: open_at이 아닌 due_at으로 변경할 지 논의 필
-  const isBeforeDeadline =
-    open_at &&
-    new Date(open_at).getTime() + 24 * 60 * 60 * 1000 > new Date().getTime();
-
   // 선택한 강의에 대한 과제 정보 가져오기
   const { data: assignmentInfo = [] } = useQuery({
     queryKey: ["assignment-info", lectureId],
@@ -111,7 +106,7 @@ export function AssignmentSubmissionSection({
             <AssignmentSubmissionItem
               userInfo={userInfo}
               submittedAssignment={submittedAssignment}
-              isBeforeDeadline={isBeforeDeadline}
+              isTodayLecture={isTodayLecture}
             />
           ) : (
             <div className="text-gray-400 text-center py-6">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #100
## 📝작업 내용
 - [x] 사용자 페이지 제출된 과제 수정 버튼 활성화 로직을 수정하였습니다.
   > `isTodayLecture`라는 서버 시간과 비교해 오늘 강의인지 판단하는 상태값이 있기 때문에 필요없는 변수인 `isBeforeDeadline`를 제거하고,  AssignmentSubmissionItem 컴포넌트에 isTodayLecture를 props로 전달해 오늘 강의일 때만 과제를 수정할 수 있게 하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
