### PR TITLE
fix: 사용자 페이지 로그인 오류 메세지 수정

### DIFF
--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -1,4 +1,5 @@
 import { supabase } from "./supabase";
+import { handleError } from "@/utils/errorHandler";
 
 export interface User {
   id: number;
@@ -39,14 +40,20 @@ export async function userLogin(email: string): Promise<LoginResponse> {
       .single();
 
     if (error) {
-      throw error;
+      if (error.code === "PGRST116") {
+        return {
+          success: false,
+          error: "등록된 이메일의 수강생이 없습니다.",
+        };
+      }
+      handleError(error, "로그인 실패");
     }
 
     if (!user) {
-      return {
-        success: false,
-        error: "해당 이메일로 등록된 사용자가 없습니다.",
-      };
+      handleError(
+        new Error("등록된 이메일의 수강생이 없습니다."),
+        "로그인 실패",
+      );
     }
 
     // 로그인 성공 시 이메일 저장
@@ -61,11 +68,7 @@ export async function userLogin(email: string): Promise<LoginResponse> {
       },
     };
   } catch (error) {
-    console.error("로그인 실패:", error);
-    return {
-      success: false,
-      error: "로그인 처리 중 오류가 발생했습니다.",
-    };
+    handleError(error, "로그인 실패");
   }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
- 사용자 페이지 로그인 오류 메세지를 수정했습니다.
  >- 기존에는 모든 오류에 대해 동일한 "로그인 처리 중 오류가 발생했습니다." 메시지가 표시되어 원인 파악이 어려웠습니다.
  >- DB에 존재하지 않는 이메일을 입력한 경우: "존재하지 않는 이메일입니다." 메시지 출력, 기타 서버 오류 또는 알 수 없는 에러는 기존대로 "로그인 처리 중 오류가 발생했습니다."를 유지합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 