### PR TITLE
feat: 사용자 페이지 과제 제출 시 이미지 업로드 기능

### DIFF
--- a/components/ui/image-preview.tsx
+++ b/components/ui/image-preview.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { X } from "lucide-react";
+
+interface ImagePreviewProps {
+  imageUrl: string;
+  onRemove?: () => void;
+  alt?: string;
+}
+
+export function ImagePreview({
+  imageUrl,
+  onRemove,
+  alt = "미리보기",
+}: ImagePreviewProps) {
+  return (
+    <div className="h-14 w-14 rounded-lg border border-gray-700 flex items-center justify-center shrink-0 relative group">
+      <img
+        src={imageUrl}
+        alt={alt}
+        className="w-full h-full object-cover rounded-lg border border-gray-700/30"
+      />
+      {onRemove && (
+        <button
+          onClick={onRemove}
+          className="absolute -top-2 -right-2 p-1 bg-red-500 hover:bg-red-600 text-white rounded-full"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/constants/files.ts
+++ b/constants/files.ts
@@ -1,0 +1,1 @@
+export const MAX_IMAGE_FILE_SIZE = 3 * 1024 * 1024; // 3MB in bytes

--- a/types/assignment.ts
+++ b/types/assignment.ts
@@ -6,6 +6,7 @@ export interface SubmittedAssignment {
   is_submit: boolean;
   submitted_at: string;
   user_id: number;
+  image_url?: string;
 }
 
 export interface DashboardAssignmentStat {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #98 

## 📝작업 내용
- [x] 사용자 페이지에서 과제 제출 시 이미지 첨부 기능
  >- 사용자 페이지에서 과제 제출 시 이미지 업로드 기능을 추가했습니다. (이미지는 필수가 아닌 선택값)
  >- 수정 시 이미지 수정 기능 가능합니다.
  >- 제출된 과제에 이미지가 있으면 이미지가 제출된 과제 영역에 보입니다.

### 스크린샷 (선택)

- 과제 제출 시
<img width="800" alt="스크린샷 2025-06-12 오후 3 31 12" src="https://github.com/user-attachments/assets/7a8da530-5d13-44b9-a27e-99923a0a80d8" />

- 제출된 과제에 이미지가 있을 경우
<img width="794" alt="스크린샷 2025-06-12 오후 3 31 42" src="https://github.com/user-attachments/assets/64f291c3-7322-46ef-b6a4-693683ad7fc5" />

- 과제 수정 시
<img width="789" alt="스크린샷 2025-06-12 오후 3 32 09" src="https://github.com/user-attachments/assets/941decba-b1db-44aa-a99d-f783c9187d98" />

## 💬리뷰 요구사항(선택)
> @wynter24 @dohyeons 제출된 과제 영역에 이미지가 보일 경우 크기를 어떻게 하면 좋을 지 의견주세요!