### PR TITLE
Feat: 기수별 강의 조회 기능 구현

### DIFF
--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { use, useEffect } from "react";
+import { useUser } from "@/hooks/auth/use-user";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import DailyLectureSection from "@/components/daily-lecture/daily-lecture-section";
+import { AssignmentSubmissionSection } from "@/components/daily-assignment/assignment-submission-section";
+import { getUserLectures, getLecturesByChallenge } from "@/apis/lectures";
+import { Lecture, LectureWithSequence } from "@/types/lecture";
+import { useSelectedLectureStore } from "@/lib/store/useSelectedLectureStore";
+import { checkIsTodayLecture } from "@/utils/date/serverTime";
+import { useChallengeStore } from "@/lib/store/useChallengeStore";
+import Header from "@/components/admin/header";
+
+type UnifiedLecture = Lecture | LectureWithSequence;
+
+export default function ClassPage({
+  params,
+}: {
+  params: Promise<{ challengeId: string }>;
+}) {
+  const router = useRouter();
+  const { data: user, isLoading } = useUser();
+  const { challengeId } = use(params);
+  const currentChallengeId = Number(challengeId);
+  const { selectedChallengeId } = useChallengeStore();
+
+  // 진행 중인 챌린지의 강의 조회
+  const { data: activeLectures = [] } = useQuery<Lecture[]>({
+    queryKey: ["daily-lectures", user?.id],
+    queryFn: async () => {
+      const data = await getUserLectures(user.id);
+      return data as unknown as Lecture[];
+    },
+    enabled: !!user?.id,
+  });
+
+  // 종료된 챌린지의 강의 조회
+  const { data: completedLectures = [] } = useQuery<LectureWithSequence[]>({
+    queryKey: ["challenge-lectures", currentChallengeId],
+    queryFn: async () => {
+      const data = await getLecturesByChallenge(currentChallengeId);
+      return data;
+    },
+    enabled:
+      !!user?.id &&
+      !activeLectures.some(
+        (lecture) => Number(lecture.challenge_id) === currentChallengeId,
+      ),
+  });
+
+  const lectures = activeLectures.some(
+    (lecture) => Number(lecture.challenge_id) === currentChallengeId,
+  )
+    ? activeLectures
+    : completedLectures;
+  const hasActiveChallenge = activeLectures.some(
+    (lecture) => Number(lecture.challenge_id) === currentChallengeId,
+  );
+
+  const onSelectedLecture = useSelectedLectureStore(
+    (state) => state.setSelectedLecture,
+  );
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      router.push("/login");
+      return;
+    }
+
+    if (lectures && lectures.length > 0) {
+      let isMounted = true;
+
+      const findTodayLecture = async () => {
+        for (const lecture of lectures) {
+          if ("open_at" in lecture) {
+            const isToday = await checkIsTodayLecture(lecture.open_at);
+            if (isToday && isMounted) {
+              onSelectedLecture(lecture as Lecture);
+              return;
+            }
+          }
+        }
+        if (isMounted) {
+          onSelectedLecture(lectures[0] as Lecture);
+        }
+      };
+
+      findTodayLecture();
+
+      return () => {
+        isMounted = false;
+      };
+    }
+  }, [user, isLoading, router, lectures]);
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#1A1D29] to-[#252A3C] text-white">
+      <Header />
+      <div className="container mx-auto px-4 py-12">
+        <div className="max-w-6xl mx-auto">
+          <div className="mb-16 text-center animate-fade-in">
+            <h1 className="text-4xl md:text-5xl font-bold mb-6 relative inline-block animate-float">
+              <span className="relative z-10">
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#5046E4] to-[#8C7DFF]">
+                  demo-funnel
+                </span>
+              </span>
+              <span className="absolute -bottom-2 left-0 right-0 h-3 bg-gradient-to-r from-[#5046E4]/20 to-[#8C7DFF]/20 rounded-full blur-sm"></span>
+            </h1>
+          </div>
+
+          <div>
+            <div className="bg-gradient-to-br from-[#252A3C] to-[#2A2F45] rounded-xl overflow-hidden shadow-lg border border-gray-700/50">
+              <div className="transition-all duration-300 hover:brightness-105">
+                <DailyLectureSection
+                  lectures={lectures}
+                  isActiveChallenge={hasActiveChallenge}
+                />
+              </div>
+
+              <AssignmentSubmissionSection userInfo={user} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer className="container mx-auto px-4 py-8 mt-20 border-t border-gray-800/50">
+        <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center">
+          <div className="text-sm text-gray-400 mb-4 md:mb-0">
+            © 2025 demo-funnel. All rights reserved.
+          </div>
+          <div className="flex space-x-6">
+            <a
+              href="#"
+              className="text-gray-400 hover:text-[#5046E4] transition-colors"
+            >
+              이용약관
+            </a>
+            <a
+              href="#"
+              className="text-gray-400 hover:text-[#5046E4] transition-colors"
+            >
+              개인정보 보호
+            </a>
+            <a
+              href="#"
+              className="text-gray-400 hover:text-[#5046E4] transition-colors"
+            >
+              문의하기
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -10,10 +10,7 @@ import { getUserLectures, getLecturesByChallenge } from "@/apis/lectures";
 import { Lecture, LectureWithSequence } from "@/types/lecture";
 import { useSelectedLectureStore } from "@/lib/store/useSelectedLectureStore";
 import { checkIsTodayLecture } from "@/utils/date/serverTime";
-import { useChallengeStore } from "@/lib/store/useChallengeStore";
-import Header from "@/components/admin/header";
-
-type UnifiedLecture = Lecture | LectureWithSequence;
+import Header from "@/components/header";
 
 export default function ClassPage({
   params,
@@ -24,7 +21,6 @@ export default function ClassPage({
   const { data: user, isLoading } = useUser();
   const { challengeId } = use(params);
   const currentChallengeId = Number(challengeId);
-  const { selectedChallengeId } = useChallengeStore();
 
   // 진행 중인 챌린지의 강의 조회
   const { data: activeLectures = [] } = useQuery<Lecture[]>({

--- a/app/class/page.tsx
+++ b/app/class/page.tsx
@@ -1,32 +1,26 @@
 "use client";
 
 import { useEffect } from "react";
-import { useUser } from "@/hooks/auth/use-user";
 import { useRouter } from "next/navigation";
+import { useUser } from "@/hooks/auth/use-user";
 import { useQuery } from "@tanstack/react-query";
-import DailyLectureSection from "@/components/daily-lecture/daily-lecture-section";
-import { AssignmentSubmissionSection } from "@/components/daily-assignment/assignment-submission-section";
-import { getUserLectures } from "@/apis/lectures";
-import { Lecture } from "@/types/lecture";
-import { useSelectedLectureStore } from "@/lib/store/useSelectedLectureStore";
-import { checkIsTodayLecture } from "@/utils/date/serverTime";
+import { getUserChallenges } from "@/apis/challenges";
+import { useChallengeStore } from '@/lib/store/useChallengeStore';
 
-export default function ClassPage() {
+export default function ClassRedirectPage() {
   const router = useRouter();
   const { data: user, isLoading } = useUser();
+  const { setSelectedChallengeId } = useChallengeStore();
 
-  const { data: lectures = [] } = useQuery({
-    queryKey: ["daily-lectures", user?.id],
+
+  const { data: challengeList = [] } = useQuery({
+    queryKey: ["challenge-list", user?.id],
     queryFn: async () => {
-      const data = await getUserLectures(user.id);
-      return data as unknown as Lecture[];
+      const data = await getUserChallenges(user.id);
+      return data;
     },
     enabled: !!user?.id,
   });
-
-  const onSelectedLecture = useSelectedLectureStore(
-    (state) => state.setSelectedLecture,
-  );
 
   useEffect(() => {
     if (!isLoading && !user) {
@@ -34,92 +28,16 @@ export default function ClassPage() {
       return;
     }
 
-    if (lectures && lectures.length > 0) {
-      let isMounted = true;
-
-      const findTodayLecture = async () => {
-        for (const lecture of lectures) {
-          const isToday = await checkIsTodayLecture(lecture.open_at);
-          if (isToday && isMounted) {
-            onSelectedLecture(lecture);
-            return;
-          }
-        }
-        if (isMounted) {
-          onSelectedLecture(lectures[0]);
-        }
-      };
-
-      findTodayLecture();
-
-      return () => {
-        isMounted = false;
-      };
+    if (challengeList && challengeList.length > 0) {
+      setSelectedChallengeId(challengeList[0].id);
+      // 가장 최근 챌린지로 리다이렉트
+      router.push(`/class/${challengeList[0].id}`);
     }
-  }, [user, isLoading, router, lectures]);
+  }, [user, isLoading, router, challengeList]);
 
   if (isLoading) {
     return <div>로딩 중...</div>;
   }
 
-  if (!user) {
-    return null;
-  }
-
-  return (
-    <div className="min-h-screen bg-gradient-to-b from-[#1A1D29] to-[#252A3C] text-white">
-      <div className="container mx-auto px-4 py-12">
-        <div className="max-w-6xl mx-auto">
-          <div className="mb-16 text-center animate-fade-in">
-            <h1 className="text-4xl md:text-5xl font-bold mb-6 relative inline-block animate-float">
-              <span className="relative z-10">
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#5046E4] to-[#8C7DFF]">
-                  demo-funnel
-                </span>
-              </span>
-              <span className="absolute -bottom-2 left-0 right-0 h-3 bg-gradient-to-r from-[#5046E4]/20 to-[#8C7DFF]/20 rounded-full blur-sm"></span>
-            </h1>
-          </div>
-
-          <div>
-            <div className="bg-gradient-to-br from-[#252A3C] to-[#2A2F45] rounded-xl overflow-hidden shadow-lg border border-gray-700/50">
-              <div className="transition-all duration-300 hover:brightness-105">
-                <DailyLectureSection lectures={lectures} />
-              </div>
-
-              <AssignmentSubmissionSection userInfo={user} />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <footer className="container mx-auto px-4 py-8 mt-20 border-t border-gray-800/50">
-        <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center">
-          <div className="text-sm text-gray-400 mb-4 md:mb-0">
-            © 2025 demo-funnel. All rights reserved.
-          </div>
-          <div className="flex space-x-6">
-            <a
-              href="#"
-              className="text-gray-400 hover:text-[#5046E4] transition-colors"
-            >
-              이용약관
-            </a>
-            <a
-              href="#"
-              className="text-gray-400 hover:text-[#5046E4] transition-colors"
-            >
-              개인정보 보호
-            </a>
-            <a
-              href="#"
-              className="text-gray-400 hover:text-[#5046E4] transition-colors"
-            >
-              문의하기
-            </a>
-          </div>
-        </div>
-      </footer>
-    </div>
-  );
+  return null;
 }

--- a/components/admin/header.tsx
+++ b/components/admin/header.tsx
@@ -143,6 +143,9 @@ export default function Header() {
                         endDate: new Date(challenge.end_date || Date.now()),
                       });
                     }
+                    if (pathname?.startsWith("/class")) {
+                      router.push(`/class/${value}`);
+                    }
                   }}
                 >
                   <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">

--- a/components/admin/header.tsx
+++ b/components/admin/header.tsx
@@ -143,9 +143,6 @@ export default function Header() {
                         endDate: new Date(challenge.end_date || Date.now()),
                       });
                     }
-                    if (pathname?.startsWith("/class")) {
-                      router.push(`/class/${value}`);
-                    }
                   }}
                 >
                   <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">

--- a/components/common/cohort-selector.tsx
+++ b/components/common/cohort-selector.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Calendar } from "lucide-react";
+
+export type CohortSelectorProps = {
+  challenges: {
+    id: number | string;
+    name: string;
+    start_date?: string;
+    end_date?: string;
+  }[];
+  selectedChallengeId: string;
+  onChange: (id: string) => void;
+};
+
+export default function CohortSelector({
+  challenges,
+  selectedChallengeId,
+  onChange,
+}: CohortSelectorProps) {
+  const selectedChallenge = challenges.find(
+    (c) => String(c.id) === selectedChallengeId,
+  );
+
+  const start = selectedChallenge?.start_date
+    ? new Date(selectedChallenge.start_date)
+    : null;
+  const end = selectedChallenge?.end_date
+    ? new Date(selectedChallenge.end_date)
+    : null;
+
+  return (
+    <div className="flex items-center gap-2 bg-[#252A3C] px-3 rounded-lg border border-gray-700/30">
+      <div className="text-white font-semibold text-sm">현재 기수</div>
+      <Select value={selectedChallengeId} onValueChange={onChange}>
+        <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">
+          <SelectValue placeholder="기수 선택" />
+        </SelectTrigger>
+        <SelectContent className="bg-[#252A3C] border border-gray-700/50 text-white min-w-[160px]">
+          {challenges.map((challenge) => (
+            <SelectItem
+              key={String(challenge.id)}
+              value={String(challenge.id)}
+              className="hover:bg-[#1C1F2B] text-white"
+            >
+              {challenge.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {start && end && (
+        <div className="hidden md:flex items-center text-sm text-gray-400 px-3 py-1.5">
+          <Calendar className="h-4 w-4 mr-2 text-[#8C7DFF]" />
+          <span>
+            {start.getMonth() + 1}월 {start.getDate()}일 ~ {end.getMonth() + 1}
+            월 {end.getDate()}일
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/daily-assignment/assignment-submission-section.tsx
+++ b/components/daily-assignment/assignment-submission-section.tsx
@@ -36,9 +36,9 @@ export function AssignmentSubmissionSection({
     useQuery({
       queryKey: ["assignment-info", lectureId],
       queryFn: async () => {
-        if (!lectureId) return null;
+        if (!lectureId) return [];
         const data = await getAssignment(lectureId);
-        return data[0]; // NOTE: 하나의 강의에 하나의 과제만 존재
+        return data[0] || []; // NOTE: 하나의 강의에 하나의 과제만 존재
       },
       enabled: !!lectureId,
     });

--- a/components/daily-lecture/daily-lecture-item.tsx
+++ b/components/daily-lecture/daily-lecture-item.tsx
@@ -2,14 +2,17 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { Lock, Calendar } from "lucide-react";
 import { getUploadTypeFromUrl, getVideoThumbnailUrl } from "@/utils/youtube";
-import { Lecture } from "@/types/lecture";
+import { Lecture, LectureWithSequence } from "@/types/lecture";
 import { isLectureOpen } from "@/utils/date/serverTime";
 
+type UnifiedLecture = Lecture | LectureWithSequence;
+
 interface DailyLectureItemProps {
-  dailyLecture: Lecture;
+  dailyLecture: UnifiedLecture;
   onLockedClick: (title: string) => void;
   onVideoSelect: (index: number) => void;
   videoIndex: number;
+  isActiveChallenge: boolean;
 }
 
 export default function DailyLectureItem({
@@ -17,23 +20,28 @@ export default function DailyLectureItem({
   onLockedClick,
   onVideoSelect,
   videoIndex,
+  isActiveChallenge,
 }: DailyLectureItemProps) {
   const upload_type = getUploadTypeFromUrl(dailyLecture.url);
-  const [locked, setLocked] = useState(true);
+  const [isLocked, setIsLocked] = useState(false);
 
   useEffect(() => {
     const checkLockStatus = async () => {
-      const isLocked = !(await isLectureOpen(dailyLecture.open_at));
-      setLocked(isLocked);
+      if (isActiveChallenge && "open_at" in dailyLecture) {
+        const locked = !(await isLectureOpen(dailyLecture.open_at));
+        setIsLocked(locked);
+      } else {
+        setIsLocked(false);
+      }
     };
     checkLockStatus();
-  }, [dailyLecture.open_at]);
+  }, [dailyLecture, isActiveChallenge]);
 
   return (
     <div
       className="relative rounded-xl overflow-hidden cursor-pointer transition-all duration-300 shadow-md hover:shadow-xl border border-gray-700/30 hover:border-gray-600/50 group"
       onClick={() =>
-        locked ? onLockedClick(dailyLecture.name) : onVideoSelect(videoIndex)
+        isLocked ? onLockedClick(dailyLecture.name) : onVideoSelect(videoIndex)
       }
     >
       <div className="aspect-video bg-gray-800 relative transform group-hover:-translate-y-1 transition-transform duration-300">
@@ -47,7 +55,7 @@ export default function DailyLectureItem({
             fill
             priority={videoIndex === 0}
             className={`object-cover transition-all duration-500 ${
-              locked ? "opacity-40 blur-[1px]" : "hover:scale-105"
+              isLocked ? "opacity-40 blur-[1px]" : "hover:scale-105"
             }`}
           />
         ) : (
@@ -55,7 +63,7 @@ export default function DailyLectureItem({
           <video
             src={dailyLecture.url}
             className={`w-full h-full object-cover ${
-              locked ? "opacity-40 blur-[1px]" : ""
+              isLocked ? "opacity-40 blur-[1px]" : ""
             }`}
             preload="metadata"
             muted
@@ -64,13 +72,13 @@ export default function DailyLectureItem({
           />
         )}
 
-        {locked ? (
+        {isLocked ? (
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 perspective-0">
             <div className="transform-none will-change-transform flex flex-col items-center justify-center">
               <Lock className="h-10 w-10 text-[#8C7DFF] drop-shadow-md mb-2" />
               <span className="text-xs font-medium text-white/90 bg-[#5046E4]/30 px-2 py-1 rounded-full backdrop-blur-sm flex items-center">
                 <Calendar className="h-3 w-3 mr-1" />
-                {dailyLecture.open_at}
+                {"open_at" in dailyLecture ? dailyLecture.open_at : ""}
               </span>
             </div>
           </div>
@@ -81,7 +89,7 @@ export default function DailyLectureItem({
       <div className="p-3 bg-[#1C1F2B]/80 backdrop-blur-sm">
         <p className="text-sm font-medium truncate">{dailyLecture.name}</p>
         <p className="text-xs text-gray-400 mt-1">
-          {locked ? "잠금 상태" : "재생 가능"}
+          {isLocked ? "잠금 상태" : "재생 가능"}
         </p>
       </div>
     </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useRouter, usePathname } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
-import { getChallenges } from "@/apis/challenges";
 import {
   Select,
   SelectContent,
@@ -10,10 +7,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useRouter, usePathname } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { getChallenges } from "@/apis/challenges";
 
 export default function Header() {
-  const router = useRouter();
   const pathname = usePathname();
+  const router = useRouter();
   const currentChallengeId = pathname.split("/").pop();
 
   const { data: challenges = [] } = useQuery({
@@ -22,33 +22,39 @@ export default function Header() {
   });
 
   return (
-    <header className="border-b border-gray-700/30 bg-[#1A1D29]/90 backdrop-blur-sm py-4 px-6 h-[74px]">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-4">
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 bg-[#252A3C] px-3 rounded-lg border border-gray-700/30">
-              <div className="text-white font-semibold text-sm">현재 기수</div>
-              <Select
-                value={currentChallengeId}
-                onValueChange={(value) => {
-                  router.push(`/class/${value}`);
-                }}
-              >
-                <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">
-                  <SelectValue placeholder="기수 선택" />
-                </SelectTrigger>
-                <SelectContent className="bg-[#252A3C] border border-gray-700/50 text-white min-w-[160px]">
-                  {challenges.map((challenge) => (
-                    <SelectItem
-                      key={String(challenge.id)}
-                      value={String(challenge.id)}
-                      className="hover:bg-[#1C1F2B] text-white"
-                    >
-                      {challenge.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+    <header className="border-b border-gray-700/30 bg-[#1A1D29]/90 backdrop-blur-sm py-4">
+      <div className="container mx-auto px-4">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2 bg-[#252A3C] px-3 rounded-lg border border-gray-700/30">
+                  <div className="text-white font-semibold text-sm">
+                    현재 기수
+                  </div>
+                  <Select
+                    value={currentChallengeId}
+                    onValueChange={(value) => {
+                      router.push(`/class/${value}`);
+                    }}
+                  >
+                    <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">
+                      <SelectValue placeholder="기수 선택" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-[#252A3C] border border-gray-700/50 text-white min-w-[160px]">
+                      {challenges.map((challenge) => (
+                        <SelectItem
+                          key={String(challenge.id)}
+                          value={String(challenge.id)}
+                          className="hover:bg-[#1C1F2B] text-white"
+                        >
+                          {challenge.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { getChallenges } from "@/apis/challenges";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export default function Header() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentChallengeId = pathname.split("/").pop();
+
+  const { data: challenges = [] } = useQuery({
+    queryKey: ["challenges"],
+    queryFn: getChallenges,
+  });
+
+  return (
+    <header className="border-b border-gray-700/30 bg-[#1A1D29]/90 backdrop-blur-sm py-4 px-6 h-[74px]">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-4">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 bg-[#252A3C] px-3 rounded-lg border border-gray-700/30">
+              <div className="text-white font-semibold text-sm">현재 기수</div>
+              <Select
+                value={currentChallengeId}
+                onValueChange={(value) => {
+                  router.push(`/class/${value}`);
+                }}
+              >
+                <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">
+                  <SelectValue placeholder="기수 선택" />
+                </SelectTrigger>
+                <SelectContent className="bg-[#252A3C] border border-gray-700/50 text-white min-w-[160px]">
+                  {challenges.map((challenge) => (
+                    <SelectItem
+                      key={String(challenge.id)}
+                      value={String(challenge.id)}
+                      className="hover:bg-[#1C1F2B] text-white"
+                    >
+                      {challenge.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #125 

## 📝작업 내용

> 기수별 강의 조회 기능 구현

<!-- ### 스크린샷 (선택) -->

## 💬리뷰 요구사항

- 관리자 페이지 헤더와 같은 UI를 사용했지만 적용된 로직이 복잡해 우선 서비스 페이지용 헤더 컴포넌트를 따로 생성하여 사용하고 있습니다. 추후 공통 UI로 분리하도록 하겠습니다!

### 플로우
- 로그인 후, 현재 진행중인 챌린지로 선택되어 첫 화면 렌더링

**관련 로직**
- `getLecturesByChallenge`: 선택한 챌린지에 해당하는 목록 조회

- 진행중인 챌린지가 있으면
`getUserChallenges`: 현재 진행중인 챌린지 강의 조회 

- 진행중인 챌린지가 없으면,
`getUserChallenges` : 수강생이 속한 챌린지 목록 조회 API 

