### PR TITLE
fix: updateLecture 강의 수정 시 입력된 과제 데이터가 없을 경우 기존 과제 삭제하는 로직 추가

### DIFF
--- a/apis/lectures.ts
+++ b/apis/lectures.ts
@@ -304,6 +304,16 @@ export async function updateLecture(lectureId: number, data: LectureData) {
           data.assignment,
         );
       }
+    } else {
+      // 입력된 과제 데이터가 없는 경우 기존 과제 삭제
+      const { error: deleteError } = await supabase
+        .from("Assignments")
+        .delete()
+        .eq("lecture_id", lectureId);
+
+      if (deleteError) {
+        handleError(deleteError, "기존 과제 삭제에 실패했습니다.");
+      }
     }
 
     return updatedLecture;


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
강의 수정 시 입력된 과제 데이터가 없을 경우 기존 과제를 삭제하도록 `updateLecture` 함수 수정했습니다.
> 기존에 과제가 있는 강의였지만 추후 과제를 삭제해야할 경우를 대비합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
