### PR TITLE
fix: 수강생이 속한 챌린지 조회

### DIFF
--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -120,7 +120,7 @@ export default function ClassPage({
             </h1>
           </div>
 
-          <div className="flex justify-items-end w-full">
+          <div className="flex justify-end w-full">
             <Header />
           </div>
 

--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -11,6 +11,7 @@ import { Lecture, LectureWithSequence } from "@/types/lecture";
 import { useSelectedLectureStore } from "@/lib/store/useSelectedLectureStore";
 import { checkIsTodayLecture } from "@/utils/date/serverTime";
 import Header from "@/components/header";
+import { useUserChallengeStore } from "@/lib/store/useUserChallengeStore";
 
 export default function ClassPage({
   params,
@@ -21,6 +22,11 @@ export default function ClassPage({
   const { data: user, isLoading } = useUser();
   const { challengeId } = use(params);
   const currentChallengeId = Number(challengeId);
+  const { setSelectedChallengeId } = useUserChallengeStore();
+
+  useEffect(() => {
+    setSelectedChallengeId(currentChallengeId);
+  }, [currentChallengeId]);
 
   // 진행 중인 챌린지의 강의 조회
   const { data: activeLectures = [] } = useQuery<Lecture[]>({
@@ -101,7 +107,6 @@ export default function ClassPage({
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#1A1D29] to-[#252A3C] text-white">
-      <Header />
       <div className="container mx-auto px-4 py-12">
         <div className="max-w-6xl mx-auto">
           <div className="mb-16 text-center animate-fade-in">
@@ -113,6 +118,10 @@ export default function ClassPage({
               </span>
               <span className="absolute -bottom-2 left-0 right-0 h-3 bg-gradient-to-r from-[#5046E4]/20 to-[#8C7DFF]/20 rounded-full blur-sm"></span>
             </h1>
+          </div>
+
+          <div className="flex justify-items-end w-full">
+            <Header />
           </div>
 
           <div>

--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -109,8 +109,8 @@ export default function ClassPage({
     <div className="min-h-screen bg-gradient-to-b from-[#1A1D29] to-[#252A3C] text-white">
       <div className="container mx-auto px-4 py-12">
         <div className="max-w-6xl mx-auto">
-          <div className="mb-16 text-center animate-fade-in">
-            <h1 className="text-4xl md:text-5xl font-bold mb-6 relative inline-block animate-float">
+          <div className="my-16 text-center animate-fade-in">
+            <h1 className="text-4xl md:text-5xl font-bold relative inline-block animate-float">
               <span className="relative z-10">
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#5046E4] to-[#8C7DFF]">
                   demo-funnel

--- a/app/class/page.tsx
+++ b/app/class/page.tsx
@@ -16,7 +16,6 @@ export default function ClassRedirectPage() {
     queryKey: ["challenge-list", user?.id],
     queryFn: async () => {
       const data = await getUserChallenges(user.id);
-      console.log(data);
       return data;
     },
     enabled: !!user?.id,

--- a/app/class/page.tsx
+++ b/app/class/page.tsx
@@ -5,18 +5,18 @@ import { useRouter } from "next/navigation";
 import { useUser } from "@/hooks/auth/use-user";
 import { useQuery } from "@tanstack/react-query";
 import { getUserChallenges } from "@/apis/challenges";
-import { useChallengeStore } from '@/lib/store/useChallengeStore';
+import { useUserChallengeStore } from "@/lib/store/useUserChallengeStore";
 
 export default function ClassRedirectPage() {
   const router = useRouter();
   const { data: user, isLoading } = useUser();
-  const { setSelectedChallengeId } = useChallengeStore();
-
+  const { setSelectedChallengeId, setChallengeList } = useUserChallengeStore();
 
   const { data: challengeList = [] } = useQuery({
     queryKey: ["challenge-list", user?.id],
     queryFn: async () => {
       const data = await getUserChallenges(user.id);
+      console.log(data);
       return data;
     },
     enabled: !!user?.id,
@@ -30,6 +30,7 @@ export default function ClassRedirectPage() {
 
     if (challengeList && challengeList.length > 0) {
       setSelectedChallengeId(challengeList[0].id);
+      setChallengeList(challengeList);
       // 가장 최근 챌린지로 리다이렉트
       router.push(`/class/${challengeList[0].id}`);
     }

--- a/components/daily-lecture/lecture-player.tsx
+++ b/components/daily-lecture/lecture-player.tsx
@@ -29,22 +29,6 @@ export default function LecturePlayer({
       <div className="p-4 md:p-6 bg-[#1A1D29]/80 backdrop-blur-sm">
         <div className="flex flex-col md:flex-row justify-between md:items-center mb-4">
           <h2 className="text-xl md:text-2xl font-bold">{title}</h2>
-          <div className="flex items-center space-x-2 mt-2 md:mt-0">
-            <Button
-              variant="outline"
-              size="sm"
-              className="rounded-full text-sm px-3 border-gray-700 bg-[#1C1F2B]/70 hover:bg-[#5046E4]/10 hover:text-[#8C7DFF] hover:border-[#5046E4]/30 flex items-center"
-            >
-              <Bookmark className="h-4 w-4 mr-1.5" /> 저장
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="rounded-full text-sm px-3 border-gray-700 bg-[#1C1F2B]/70 hover:bg-[#5046E4]/10 hover:text-[#8C7DFF] hover:border-[#5046E4]/30 flex items-center"
-            >
-              <Share2 className="h-4 w-4 mr-1.5" /> 공유
-            </Button>
-          </div>
         </div>
         <p className="text-sm text-gray-400 mb-2">{description}</p>
       </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -17,42 +17,30 @@ export default function Header() {
   const { challengeList } = useUserChallengeStore();
 
   return (
-    <header className="border-b border-gray-700/30 bg-[#1A1D29]/90 backdrop-blur-sm py-4">
-      <div className="container mx-auto">
-        <div className="max-w-6xl mx-auto">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 bg-[#252A3C] px-3 rounded-lg border border-gray-700/30">
-                  <div className="text-white font-semibold text-sm">
-                    현재 기수
-                  </div>
-                  <Select
-                    value={currentChallengeId}
-                    onValueChange={(value) => {
-                      router.push(`/class/${value}`);
-                    }}
-                  >
-                    <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">
-                      <SelectValue placeholder="기수 선택" />
-                    </SelectTrigger>
-                    <SelectContent className="bg-[#252A3C] border border-gray-700/50 text-white min-w-[160px]">
-                      {challengeList.map((challenge) => (
-                        <SelectItem
-                          key={String(challenge.id)}
-                          value={String(challenge.id)}
-                          className="hover:bg-[#1C1F2B] text-white"
-                        >
-                          {challenge.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+    <header className="py-4 w-full flex justify-end pr-4">
+      <div className="flex items-center gap-2 bg-[#252A3C] px-3 rounded-lg border border-gray-700/30">
+        <div className="text-white font-semibold text-sm">현재 기수</div>
+        <Select
+          value={currentChallengeId}
+          onValueChange={(value) => {
+            router.push(`/class/${value}`);
+          }}
+        >
+          <SelectTrigger className="w-[120px] border-0 bg-transparent focus:ring-0 text-white">
+            <SelectValue placeholder="기수 선택" />
+          </SelectTrigger>
+          <SelectContent className="bg-[#252A3C] border border-gray-700/50 text-white min-w-[160px]">
+            {challengeList.map((challenge) => (
+              <SelectItem
+                key={String(challenge.id)}
+                value={String(challenge.id)}
+                className="hover:bg-[#1C1F2B] text-white"
+              >
+                {challenge.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
     </header>
   );

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -7,23 +7,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useUserChallengeStore } from "@/lib/store/useUserChallengeStore";
 import { useRouter, usePathname } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
-import { getChallenges } from "@/apis/challenges";
 
 export default function Header() {
   const pathname = usePathname();
   const router = useRouter();
   const currentChallengeId = pathname.split("/").pop();
-
-  const { data: challenges = [] } = useQuery({
-    queryKey: ["challenges"],
-    queryFn: getChallenges,
-  });
+  const { challengeList } = useUserChallengeStore();
 
   return (
     <header className="border-b border-gray-700/30 bg-[#1A1D29]/90 backdrop-blur-sm py-4">
-      <div className="container mx-auto px-4">
+      <div className="container mx-auto">
         <div className="max-w-6xl mx-auto">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
@@ -42,7 +37,7 @@ export default function Header() {
                       <SelectValue placeholder="기수 선택" />
                     </SelectTrigger>
                     <SelectContent className="bg-[#252A3C] border border-gray-700/50 text-white min-w-[160px]">
-                      {challenges.map((challenge) => (
+                      {challengeList.map((challenge) => (
                         <SelectItem
                           key={String(challenge.id)}
                           value={String(challenge.id)}

--- a/lib/store/useUserChallengeStore.ts
+++ b/lib/store/useUserChallengeStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type UserChallenge = {
+  id: number;
+  name: string;
+};
+
+interface UserChallengeState {
+  selectedChallengeId: number;
+  challengeList: UserChallenge[];
+  setSelectedChallengeId: (id: number) => void;
+  setChallengeList: (list: UserChallenge[]) => void;
+}
+
+export const useUserChallengeStore = create<UserChallengeState>()(
+  persist(
+    (set) => ({
+      selectedChallengeId: 0,
+      challengeList: [],
+      setSelectedChallengeId: (id: number) => set({ selectedChallengeId: id }),
+      setChallengeList: (list: UserChallenge[]) =>
+        set({ challengeList: list }),
+    }),
+    {
+      name: "user-challenge-store", // localStorage key
+    }
+  )
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #138

## 📝작업 내용

- 현재 모든 챌린지 조회에서 수강생이 속한 챌린지만 조회할 수 있도록 수정
- 위치 변경 (왼쪽 상단 -> 로고 아래 오른쪽)
- 공유 및 저장 버튼 제거

### 스크린샷 

![image](https://github.com/user-attachments/assets/6abd2b37-e421-47b1-88ab-ea76c139cfbf)

## 💬리뷰 요구사항

- cursor 무료 사용량을 초과해서 직접 디자인을 수정하다 보니 위치나 여백이 생각보다 안 예쁠 수 있어요...ㅎㅎ
보시고 편하게 수정하시면 됩니다!

- admin에서 사용하고 있는 전역 데이터를 사용자 페이지에서도 사용하고 있어, 스토어를 새로 생성하고 관련 코드를 수정한다고 생각보다 시간이 더 걸렸네요ㅠ

- 컴포넌트 분리 및 지저분한 코드는 다음 이슈에서 작업하겠습니다!
