### PR TITLE
수강관리의 강의 표시방식 변경

### DIFF
--- a/apis/users.ts
+++ b/apis/users.ts
@@ -253,7 +253,7 @@ export async function getStudentSubmissions(
     const { data: challengeLectures, error: challengeLecturesError } =
       await supabase
         .from("ChallengeLectures")
-        .select("id, lecture_id, due_at")
+        .select("id, lecture_id, due_at, sequence")
         .eq("challenge_id", challengeId)
         .order("sequence", { ascending: true });
 
@@ -388,6 +388,7 @@ export async function getStudentSubmissions(
               dueDate: lecture.due_at,
               isSubmitted,
               submissionId: submissions?.[0]?.id,
+              sequence: lecture.sequence,
               assignments: assignments.length > 0 ? assignments : undefined,
             };
           }),

--- a/components/admin/course-info/StudentTable.tsx
+++ b/components/admin/course-info/StudentTable.tsx
@@ -7,7 +7,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Check, X } from "lucide-react";
-import { StudentSubmission } from "@/types/user";
+import { StudentSubmission, SubmissionStatus } from "@/types/user";
 
 interface StudentTableProps {
   students: StudentSubmission[];
@@ -16,6 +16,29 @@ interface StudentTableProps {
     lectureIndex: number,
   ) => void;
 }
+
+const getLectureTitle = (submissions: SubmissionStatus[], index: number) => {
+  const currentSubmission = submissions[index];
+  const sequence = currentSubmission.sequence;
+
+  // 같은 sequence를 가진 강의들을 찾음
+  const sameSequenceLectures = submissions.filter(
+    (sub) => sub.sequence === sequence,
+  );
+
+  // 같은 sequence의 강의가 여러 개일 경우에만 번호를 붙임
+  if (sameSequenceLectures.length > 1) {
+    // 현재 강의가 같은 sequence 중 몇 번째인지 찾음
+    const order =
+      sameSequenceLectures.findIndex(
+        (sub) =>
+          sub.challengeLectureId === currentSubmission.challengeLectureId,
+      ) + 1;
+    return `${sequence}-${order} 강`;
+  }
+
+  return `${sequence} 강`;
+};
 
 export function StudentTable({
   students,
@@ -85,7 +108,7 @@ export function StudentTable({
                           : "80px",
                     }}
                   >
-                    {index + 1}강
+                    {getLectureTitle(students[0].submissions, index)}
                   </TableHead>
                 ))}
               </TableRow>

--- a/hooks/admin/useExportToExcel.ts
+++ b/hooks/admin/useExportToExcel.ts
@@ -23,6 +23,29 @@ function formatDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+function getLectureTitle(submissions: any[], index: number) {
+  const currentSubmission = submissions[index];
+  const sequence = currentSubmission.sequence;
+
+  // 같은 sequence를 가진 강의들을 찾음
+  const sameSequenceLectures = submissions.filter(
+    (sub) => sub.sequence === sequence,
+  );
+
+  // 같은 sequence의 강의가 여러 개일 경우에만 번호를 붙임
+  if (sameSequenceLectures.length > 1) {
+    // 현재 강의가 같은 sequence 중 몇 번째인지 찾음
+    const order =
+      sameSequenceLectures.findIndex(
+        (sub) =>
+          sub.challengeLectureId === currentSubmission.challengeLectureId,
+      ) + 1;
+    return `${sequence}-${order}강`;
+  }
+
+  return `${sequence}강`;
+}
+
 export function useExportToExcel({
   searchQuery,
   showCompletedOnly,
@@ -71,9 +94,8 @@ export function useExportToExcel({
 
         // 각 강의별 제출 상태 추가
         student.submissions.forEach((submission, idx) => {
-          baseData[`${idx + 1}강 제출여부`] = submission.isSubmitted
-            ? "제출"
-            : "미제출";
+          baseData[`${getLectureTitle(student.submissions, idx)} 제출여부`] =
+            submission.isSubmitted ? "제출" : "미제출";
         });
 
         return baseData;

--- a/types/user.ts
+++ b/types/user.ts
@@ -21,6 +21,7 @@ export interface SubmissionStatus {
   isSubmitted: boolean;
   dueDate: string;
   submissionId?: number;
+  sequence: number;
   assignments?: {
     url: string;
     comment: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #112

## 📝작업 내용

> 수강 정보 페이지에서의 강의 표시 방식을 1강 2강 3강.... 에서 n-m강으로 바꿨습니다. 강의가 하나밖에 없는 날은 n강으로 보입니다.

### 스크린샷 (선택)
<img width="304" alt="스크린샷 2025-06-13 오후 5 23 34" src="https://github.com/user-attachments/assets/8e1c0736-ad0b-4811-8139-a4c46047a56d" />
에서

<img width="325" alt="스크린샷 2025-06-13 오후 5 23 53" src="https://github.com/user-attachments/assets/5708be9e-62c3-4a75-8262-30ec0f0df8ce" />
로 바꿨습니다.

## 💬리뷰 요구사항(선택)

