### PR TITLE
fix: getLecturesByChallenge 함수 호출 시 open_at도 반환하도록 수정

### DIFF
--- a/apis/lectures.ts
+++ b/apis/lectures.ts
@@ -515,6 +515,7 @@ export async function getLecturesByChallenge(
         `
         lecture_id,
         sequence,
+        open_at,
         Lectures (
           id,
           name,
@@ -546,6 +547,7 @@ export async function getLecturesByChallenge(
         created_at: item.Lectures.created_at,
         updated_at: item.Lectures.updated_at,
         sequence: item.sequence,
+        open_at: item.open_at,
         assignment_title: item.Lectures.Assignments?.[0]?.title || "",
         assignment: item.Lectures.Assignments?.[0]?.contents || "",
       })) || [];

--- a/types/lecture.ts
+++ b/types/lecture.ts
@@ -38,6 +38,7 @@ export interface LectureData {
 export interface ChallengeLectures {
   lecture_id: number;
   sequence: number;
+  open_at: string;
   Lectures: {
     id: number;
     name: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
- getLecturesByChallenge 함수 호출 시 open_at도 반환하도록 수정
  > 기존에 open_at 값을 포함하지 않고 있어 프론트단에서 사용하는데에 이슈가 있었습니다. 이를 해결하기 위해 open_at도 반환하도록 수정했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> @wynter24 함수 수정했습니다! 화면단에서 작업해보시고 또 다른 이슈나 필요한 부분이 있다면 알려주세요 ^.^!
