### PR TITLE
pageTitle을 layout에서 렌더링

### DIFF
--- a/app/admin/(dashboard)/challenges/page.test.tsx
+++ b/app/admin/(dashboard)/challenges/page.test.tsx
@@ -104,9 +104,7 @@ jest.mock("@/components/admin/challenges/edit-challenge-dialog", () => ({
 
 jest.mock("@/components/ui/page-title", () => ({
   __esModule: true,
-  default: ({ title }: { title: string }) => (
-    <h1 data-testid="page-title">{title}</h1>
-  ),
+  default: () => null,
 }));
 
 // useChallenges 훅 모킹
@@ -184,12 +182,7 @@ describe("ChallengesPage", () => {
       });
     });
 
-    it("페이지 타이틀이 올바르게 표시된다", () => {
-      render(<ChallengesPage />);
-      expect(screen.getByTestId("page-title")).toHaveTextContent("챌린지 관리");
-    });
-
-    it("InfoTable에 챌린지 데이터가 표시된다", () => {
+    it("챌린지 목록이 올바르게 표시된다", () => {
       render(<ChallengesPage />);
       const challengeRows = screen.getAllByTestId("challenge-row");
       expect(challengeRows).toHaveLength(mockChallenges.length);

--- a/app/admin/(dashboard)/course-info/page.tsx
+++ b/app/admin/(dashboard)/course-info/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import PageTitle from "@/components/ui/page-title";
 import SearchFilter from "@/components/admin/course-info/search-filter";
 import CourseInfoTable from "@/components/admin/course-info-table";
 
@@ -11,7 +10,6 @@ export default function CourseInfoPage() {
 
   return (
     <div className="space-y-4">
-      <PageTitle title="수강 정보 관리" />
       <SearchFilter
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}

--- a/app/admin/(dashboard)/course-info/pege.test.tsx
+++ b/app/admin/(dashboard)/course-info/pege.test.tsx
@@ -3,8 +3,8 @@ import CourseInfoPage from "./page";
 
 // Mock components
 jest.mock("@/components/ui/page-title", () => {
-  return function MockPageTitle({ title }: { title: string }) {
-    return <h1>{title}</h1>;
+  return function MockPageTitle() {
+    return null; // 테스트에서는 PageTitle 렌더링하지 않음
   };
 });
 
@@ -48,10 +48,12 @@ jest.mock("@/components/admin/course-info-table", () => {
     showCompletedOnly: boolean;
   }) {
     return (
-      <div>
-        <div data-testid="passed-search-query">{searchQuery}</div>
-        <div data-testid="passed-show-completed">
-          {showCompletedOnly.toString()}
+      <div className="bg-[#252A3C] border border-gray-700/30 rounded-xl overflow-hidden shadow-lg">
+        <div>
+          <div data-testid="passed-search-query">{searchQuery}</div>
+          <div data-testid="passed-show-completed">
+            {showCompletedOnly.toString()}
+          </div>
         </div>
       </div>
     );
@@ -59,14 +61,16 @@ jest.mock("@/components/admin/course-info-table", () => {
 });
 
 describe("CourseInfoPage", () => {
-  it("renders page title correctly", () => {
+  it("초기 상태가 올바르게 설정되어 있다", () => {
     render(<CourseInfoPage />);
-    expect(screen.getByText("수강 정보 관리")).toBeInTheDocument();
+    expect(screen.getByTestId("passed-search-query")).toHaveTextContent("");
+    expect(screen.getByTestId("passed-show-completed")).toHaveTextContent(
+      "false",
+    );
   });
 
-  it("updates searchQuery when input value changes", () => {
+  it("검색어 입력 시 검색 쿼리가 업데이트된다", () => {
     render(<CourseInfoPage />);
-
     const searchInput = screen.getByTestId("search-input");
     fireEvent.change(searchInput, { target: { value: "React" } });
 
@@ -74,9 +78,8 @@ describe("CourseInfoPage", () => {
     expect(passedSearchQuery).toHaveTextContent("React");
   });
 
-  it("toggles showCompletedOnly when checkbox is clicked", () => {
+  it("완료 여부 체크박스 토글이 정상 동작한다", () => {
     render(<CourseInfoPage />);
-
     const checkbox = screen.getByTestId("completed-checkbox");
     const passedShowCompleted = screen.getByTestId("passed-show-completed");
 
@@ -92,14 +95,8 @@ describe("CourseInfoPage", () => {
     expect(passedShowCompleted).toHaveTextContent("false");
   });
 
-  it("passes correct props to MainContent", () => {
+  it("검색과 필터링이 함께 동작한다", () => {
     render(<CourseInfoPage />);
-
-    // 초기값 확인
-    expect(screen.getByTestId("passed-search-query")).toHaveTextContent("");
-    expect(screen.getByTestId("passed-show-completed")).toHaveTextContent(
-      "false",
-    );
 
     // 검색어 입력
     const searchInput = screen.getByTestId("search-input");

--- a/app/admin/(dashboard)/layout.tsx
+++ b/app/admin/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import Sidebar from "@/components/admin/sidebar";
 import Header from "@/components/admin/header";
+import PageTitle from "@/components/ui/page-title";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -22,7 +23,10 @@ export default function DashboardLayout({
       <Sidebar />
       <main className="flex-1 overflow-y-auto bg-[#1C1F2B] text-white">
         <Header />
-        <div className="p-6 space-y-6">{children}</div>
+        <div className="p-6 space-y-6">
+          <PageTitle />
+          {children}
+        </div>
       </main>
     </div>
   );

--- a/app/admin/(dashboard)/students/page.tsx
+++ b/app/admin/(dashboard)/students/page.tsx
@@ -1,10 +1,8 @@
 import StudentList from "@/components/admin/student-list";
-import PageTitle from "@/components/ui/page-title";
 
 export default function StudentsPage() {
   return (
     <>
-      <PageTitle title="수강생 관리" />
       <StudentList />
     </>
   );

--- a/components/admin/challenges/challenges-content.tsx
+++ b/components/admin/challenges/challenges-content.tsx
@@ -8,7 +8,6 @@ import AddChallengeDialog from "./add-challenge-dialog";
 import EditChallengeDialog from "./edit-challenge-dialog";
 import InfoTable from "@/components/admin/info-table";
 import { Button } from "@/components/ui/button";
-import PageTitle from "@/components/ui/page-title";
 import {
   ChallengesState,
   ChallengesStatus,
@@ -82,7 +81,6 @@ export default function ChallengesContent({
 
   return (
     <div className="space-y-4">
-      <PageTitle title="챌린지 관리" />
       <div className="flex justify-end">
         <AddChallengeDialog
           isOpen={dialog.isAddDialogOpen}

--- a/components/admin/dashboard/dashboard-page.tsx
+++ b/components/admin/dashboard/dashboard-page.tsx
@@ -63,13 +63,7 @@ export default function DashboardPage() {
 
   return (
     <div className="flex flex-col min-h-screen">
-      <div className="p-6 md:p-8 space-y-6 animate-fade-in">
-        <h1 className="text-2xl md:text-3xl font-bold">
-          <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#5046E4] to-[#8C7DFF]">
-            demo-funnel 관리자 대시보드
-          </span>
-        </h1>
-
+      <div className=" space-y-6 animate-fade-in">
         {isLoading ? (
           <div className="flex justify-center items-center py-8">
             <Loader2 className="h-8 w-8 animate-spin text-[#8C7DFF]" />

--- a/components/admin/lectures/lectures-content.tsx
+++ b/components/admin/lectures/lectures-content.tsx
@@ -17,7 +17,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import PageTitle from "@/components/ui/page-title";
 
 export default function LecturesContent() {
   const [isOpen, setIsOpen] = useState(false);
@@ -73,7 +72,6 @@ export default function LecturesContent() {
   return (
     <>
       <div className="space-y-4">
-        <PageTitle title="강의 관리" />
         <div className="flex justify-end">
           <Dialog open={isOpen} onOpenChange={setIsOpen}>
             <DialogTrigger asChild>

--- a/components/ui/page-title.tsx
+++ b/components/ui/page-title.tsx
@@ -1,8 +1,23 @@
-export default function PageTitle({ title }: { title: string }) {
+"use client";
+
+import { usePathname } from "next/navigation";
+import { ADMIN_TITLE } from "@/constants/admin-title";
+
+type AdminTitleKey = keyof typeof ADMIN_TITLE;
+
+export default function PageTitle({ title }: { title?: string }) {
+  const pathname = usePathname();
+  const getAdminTitle = () => {
+    if (title) return title;
+
+    const path = pathname.split("/").pop()?.toUpperCase() as AdminTitleKey;
+    return ADMIN_TITLE[path] || "관리자";
+  };
+
   return (
     <h1 className="text-2xl font-bold">
       <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#5046E4] to-[#8C7DFF]">
-        {title}
+        {getAdminTitle()}
       </span>
     </h1>
   );

--- a/constants/admin-title.ts
+++ b/constants/admin-title.ts
@@ -1,0 +1,8 @@
+export const ADMIN_TITLE = {
+  CHALLENGES: "챌린지 관리",
+  LECTURES: "강의 관리",
+  STUDENTS: "수강생 관리",
+  "COURSE-INFO": "수강 정보 관리",
+  EMAIL: "이메일 관리",
+  ADMIN: "대시보드",
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #64 

## 📝작업 내용

> admin 페이지들의 타이틀을 layout에서 렌더링하도록 구현했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
