### PR TITLE
fix: YouTube 썸네일 blur placeholder 오류 수정 

### DIFF
--- a/components/class/lecture-player.tsx
+++ b/components/class/lecture-player.tsx
@@ -73,7 +73,6 @@ export default function LecturePlayer({
                     priority
                     sizes="(max-width: 768px) 100vw, 80vw"
                     quality={75}
-                    placeholder="blur"
                   />
                 )
               ) : (


### PR DESCRIPTION
## #️⃣연관된 이슈

> #177

## 📝작업 내용 

> 로컬에만 발생하는 blur placeholder 에러 해결

<!-- ### 스크린샷 (선택) -->

## 💬리뷰 요구사항

> 발생 원인: 외부 이미지 URL(YouTube 썸네일)을 사용할 때는 Next.js의 blur placeholder 기능을 사용할 수 없기 때문

`placeholder="blur"` 속성 하나만 제거하면 되지만 혹시 몰라 충돌 발생 위험을 예방하고자 pr 올립니다!
다음에는 한 번 더 확인하겠습니다!🥲