### PR TITLE
Feat/main/admin refactoring #173

### DIFF
--- a/components/admin/dashboard/dashboard-page.tsx
+++ b/components/admin/dashboard/dashboard-page.tsx
@@ -3,24 +3,12 @@
 import { Loader2 } from "lucide-react";
 import SummaryCards from "./summary-cards";
 import DetailedStats from "./detailed-stats";
-import { useQuery } from "@tanstack/react-query";
 import { useChallengeStore } from "@/lib/store/useChallengeStore";
-import { DashboardAssignmentStat } from "@/types/assignment";
 import { usePeriodComparison } from "@/hooks/admin/usePeriodComparison";
-import { getAssignmentStats } from "@/apis/assignments";
+import { useAssignmentState } from "@/hooks/admin/useAssignmentState";
 
 export default function DashboardPage() {
   const { selectedChallengeId } = useChallengeStore();
-
-  const { data: currentAssignmentState = [], isLoading: isLoadingCurrent } =
-    useQuery<DashboardAssignmentStat[]>({
-      queryKey: ["challengeUsers", selectedChallengeId],
-      queryFn: async () => {
-        const data = await getAssignmentStats(selectedChallengeId);
-        return data;
-      },
-      enabled: !!selectedChallengeId,
-    });
 
   const previousChallengeId =
     selectedChallengeId && selectedChallengeId > 1
@@ -28,15 +16,11 @@ export default function DashboardPage() {
       : undefined;
   const isFirstPeriod = selectedChallengeId === 1;
 
+  const { data: currentAssignmentState = [], isLoading: isLoadingCurrent } =
+    useAssignmentState(selectedChallengeId);
+
   const { data: previousAssignmentState = [], isLoading: isLoadingPrevious } =
-    useQuery<DashboardAssignmentStat[]>({
-      queryKey: ["challengeUsers", previousChallengeId],
-      queryFn: async () => {
-        const data = await getAssignmentStats(previousChallengeId);
-        return data;
-      },
-      enabled: !!previousChallengeId,
-    });
+    useAssignmentState(previousChallengeId);
 
   const {
     currentValue: currentTotalStudent,

--- a/components/admin/dashboard/dashboard-page.tsx
+++ b/components/admin/dashboard/dashboard-page.tsx
@@ -8,7 +8,9 @@ import { usePeriodComparison } from "@/hooks/admin/usePeriodComparison";
 import { useAssignmentState } from "@/hooks/admin/useAssignmentState";
 
 export default function DashboardPage() {
-  const { selectedChallengeId } = useChallengeStore();
+  const selectedChallengeId = useChallengeStore(
+    (state) => state.selectedChallengeId,
+  );
 
   const previousChallengeId =
     selectedChallengeId && selectedChallengeId > 1

--- a/hooks/admin/useAssignmentState.ts
+++ b/hooks/admin/useAssignmentState.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { DashboardAssignmentStat } from "@/types/assignment";
+import { getAssignmentStats } from "@/apis/assignments";
+
+export const useAssignmentState = (challengeId: number) => {
+  return useQuery<DashboardAssignmentStat[]>({
+    queryKey: ["challengeUsers", challengeId],
+    queryFn: async () => {
+      const data = await getAssignmentStats(challengeId);
+      return data;
+    },
+    enabled: !!challengeId,
+  });
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
#173 

## 📝작업 내용
- 대시보드 페이지에서 중복적으로 호출되는 useQuery를 커스텀 훅으로 구현해서 중복 제거
- 대시보드 페이지에서 useChallengeStore에서 selectedChallengeId를 불러올 때 selector 함수를 사용해서 해당 값만 가져오도록 수정