### PR TITLE
Fix: 렌더링 시, 오늘의 강의가 선택되지 않는 문제 해결

### DIFF
--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -24,7 +24,7 @@ export default async function Class({
 
   await queryClient.prefetchQuery({
     queryKey: ["challenge-lectures", currentChallengeId],
-    queryFn: () => lectures, // 이미 불러온 걸 사용
+    queryFn: () => lectures,
   });
 
   return (

--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -1,5 +1,6 @@
 import { getLecturesByChallenge } from "@/apis/lectures";
 import ClassPage from "@/components/class/ClassPage";
+import { findTodayLectureIndex } from '@/utils/date/serverTime';
 import {
   dehydrate,
   HydrationBoundary,
@@ -15,17 +16,20 @@ export default async function Class({
   const { challengeId } = await params;
   const currentChallengeId = Number(challengeId);
 
+  const lectures = await getLecturesByChallenge(currentChallengeId);
+
+  // 오늘 강의 찾기
+  const todayIndex = await findTodayLectureIndex(lectures);
+  const initialLecture = todayIndex !== -1 ? lectures[todayIndex] : lectures[0];
+
   await queryClient.prefetchQuery({
     queryKey: ["challenge-lectures", currentChallengeId],
-    queryFn: async () => {
-      const data = await getLecturesByChallenge(currentChallengeId);
-      return data;
-    },
+    queryFn: () => lectures, // 이미 불러온 걸 사용
   });
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <ClassPage currentChallengeId={currentChallengeId} />
+      <ClassPage currentChallengeId={currentChallengeId} initialLecture={initialLecture} />
     </HydrationBoundary>
   );
 }

--- a/components/class/ClassPage.tsx
+++ b/components/class/ClassPage.tsx
@@ -80,7 +80,11 @@ export default function ClassPage({
       </div>
     );
   }
-
+  
+  useEffect(() => {
+    setSelectedLecture(initialLecture); // CSR 진입 시 딱 한 번만 반영
+  }, [initialLecture, setSelectedLecture]);
+  
   const isLoading = isLecturesLoading;
 
   if (isLoading) {

--- a/components/class/ClassPage.tsx
+++ b/components/class/ClassPage.tsx
@@ -64,7 +64,6 @@ export default function ClassPage({
     challengeLectures,
   );
 
-
   // 사용자가 없을 때 리디렉션
   useEffect(() => {
     if (!isLoadingUser && !user) {
@@ -72,22 +71,12 @@ export default function ClassPage({
     }
   }, [isLoadingUser, user, router]);
 
-  // 로딩 중이거나 사용자가 없으면 로딩 화면 표시
-  if (isLoadingUser || !user) {
-    return (
-      <div className="flex justify-center items-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-[#8C7DFF]" />
-      </div>
-    );
-  }
-  
   useEffect(() => {
     setSelectedLecture(initialLecture); // CSR 진입 시 딱 한 번만 반영
   }, [initialLecture, setSelectedLecture]);
-  
-  const isLoading = isLecturesLoading;
 
-  if (isLoading) {
+  // 로딩 중이거나 사용자가 없으면 로딩 화면 표시
+  if (isLoadingUser || !user || isLecturesLoading) {
     return (
       <div className="flex justify-center items-center min-h-screen">
         <Loader2 className="h-8 w-8 animate-spin text-[#8C7DFF]" />

--- a/components/class/ClassPage.tsx
+++ b/components/class/ClassPage.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { use, useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useUser } from "@/hooks/auth/useUser";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { getLecturesByChallenge } from "@/apis/lectures";
 import { LectureWithSequence } from "@/types/lecture";
 import { useSelectedLectureStore } from "@/lib/store/useSelectedLectureStore";
-import { findTodayLectureIndex } from "@/utils/date/serverTime";
 import { getUserChallenges } from "@/apis/challenges";
 import CohortSelector from "@/components/common/cohort-selector";
 import { useRefundStatus } from "@/hooks/class/useRefundStatus";
@@ -16,11 +15,15 @@ import DailyLectureSection from "@/components/class/DailyLectureSection";
 import RefundRequestButton from "@/components/class/RefundRequestButton";
 import { Loader2 } from "lucide-react";
 
+interface ClassPageProps {
+  currentChallengeId: number;
+  initialLecture: LectureWithSequence;
+}
+
 export default function ClassPage({
   currentChallengeId,
-}: {
-  currentChallengeId: number;
-}) {
+  initialLecture,
+}: ClassPageProps) {
   const router = useRouter();
   const { data: user, isLoading: isLoadingUser } = useUser();
 
@@ -49,9 +52,7 @@ export default function ClassPage({
     staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
   });
 
-  const onSelectedLecture = useSelectedLectureStore(
-    (state) => state.setSelectedLecture,
-  );
+  const setSelectedLecture = useSelectedLectureStore((s) => s.setSelectedLecture);
 
   const challengeLectures = lectures.map((lecture) => ({
     id: lecture.challenge_lecture_id,
@@ -63,7 +64,6 @@ export default function ClassPage({
     challengeLectures,
   );
 
-  const hasSelectedLecture = useRef(false);
 
   // 사용자가 없을 때 리디렉션
   useEffect(() => {
@@ -71,27 +71,6 @@ export default function ClassPage({
       router.push("/login");
     }
   }, [isLoadingUser, user, router]);
-
-  useEffect(() => {
-    if (
-      isLoadingUser ||
-      !user ||
-      lectures.length === 0 ||
-      hasSelectedLecture.current
-    )
-      return;
-
-    hasSelectedLecture.current = true;
-
-    const checkTodayLecture = async () => {
-      const todayIndex = await findTodayLectureIndex(lectures);
-      const targetLecture =
-        todayIndex !== -1 ? lectures[todayIndex] : lectures[0];
-      onSelectedLecture(targetLecture);
-    };
-
-    checkTodayLecture();
-  }, [lectures, onSelectedLecture, isLoadingUser, user]);
 
   // 로딩 중이거나 사용자가 없으면 로딩 화면 표시
   if (isLoadingUser || !user) {

--- a/utils/date/serverTime.ts
+++ b/utils/date/serverTime.ts
@@ -16,7 +16,12 @@ export const getServerTime = async (): Promise<string> => {
   }
 
   try {
-    const { data } = await axios.get("/api/server-time");
+    const baseUrl =
+    typeof window === "undefined"
+      ? process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+      : "";
+    const { data } = await axios.get(`${baseUrl}/api/server-time`);
+    
     cachedServerTime = data.serverTime;
     lastFetchTime = now;
     return data.serverTime;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #184

## 📝작업 내용

> 로컬 환경에서 렌더링 시, 오늘의 강의가 선택되지 않는 문제 해결

<!-- ### 스크린샷 (선택) -->

## 💬리뷰 요구사항

### 로컬 환경에서 렌더링 시, 오늘의 강의가 선택되지 않는 문제

#### 문제
로그인 후 또는 /class/[challengeId] 페이지에서 새로고침 시, 오늘 날짜의 강의가 잠깐 선택되었다가 첫 번째 강의로 덮어씌워지는 현상 발생

#### 원인
- hydration 중 zustand store가 초기값(lectureId: 0)으로 잠깐 되돌아가면서 DailyLectureSection에서 첫 번째 강의가 선택되어 다시 상태가 변경되는 문제
- **React 개발 환경(Strict Mode)** 에서는 렌더링 및 useEffect가 두 번 실행되기 때문에 이 문제가 더 쉽게 재현됨
- 반면, 배포 환경에서는 hydration 타이밍이 안정적이라 문제 발생 확률이 낮음

#### 해결
- 서버 컴포넌트에서 오늘 강의를 사전에 판단하여 initialLecture로 prop 전달
- 클라이언트에서는 CSR 진입 시 initialLecture를 zustand 상태에 한 번만 반영하도록 처리하여 상태 꼬임 방지

> 참고: 해당 문제는 실제 사용자 환경에서도 발생할 수 있어 개발 환경에서 사전 캐치 및 구조 개선이 필요했습니다.

### ✅ 환경 변수 추가
- SSR 환경에서 서버 시간 axios.get("/api/server-time") 호출 시 base URL 없음 → Invalid URL 발생
```tsx
const baseUrl =
  typeof window === "undefined"
    ? process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
    : "";

const { data } = await axios.get(`${baseUrl}/api/server-time`);
```
- SSR 환경에서 서버 시간을 가져오는 로직을 사용하면서 Invalid URL 발생이 발생하여 위와 같이 처러했습니다.
- 그래서 환경 변수에 NEXT_PUBLIC_BASE_URL 추가해주시면 감사하겠습니다:)
상세 내용은 노션 `환경변수` 페이지에 추가했습니다.

---
비슷한 이유로 이전 이슈가 제 로컬 환경에서에서 발생하지 않은 이유가 각 개발 환경이 다르기 때문인 것 같기도 해요!
이 부분은 더 고민해보고 최대한 여러 상황 고려해서 코드 짜도록 하겠습니다!