### PR TITLE
Refactor: 서비스 페이지 UI/비지니스 로직 분리

### DIFF
--- a/app/class/[challengeId]/page.tsx
+++ b/app/class/[challengeId]/page.tsx
@@ -6,6 +6,7 @@ import {
   HydrationBoundary,
   QueryClient,
 } from "@tanstack/react-query";
+import { notFound } from "next/navigation";
 
 export default async function Class({
   params,
@@ -15,6 +16,10 @@ export default async function Class({
   const queryClient = new QueryClient();
   const { challengeId } = await params;
   const currentChallengeId = Number(challengeId);
+
+  if (isNaN(currentChallengeId)) {
+    notFound();
+  }
 
   const lectures = await getLecturesByChallenge(currentChallengeId);
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     "매일 하나의 강의를 듣고 과제를 제출하는 학습 플랫폼입니다. 꾸준한 학습을 통해 실력을 키워보세요.",
   generator: "Next.js",
   icons: {
-    icon: "./icon.ico",
+    icon: "/icon.ico",
   },
   openGraph: {
     title: "demo funnel",

--- a/components/class/ClassFooter.tsx
+++ b/components/class/ClassFooter.tsx
@@ -1,0 +1,31 @@
+export default function ClassFooter() {
+  return (
+    <footer className="container mx-auto px-4 py-8 mt-20 border-t border-gray-800/50">
+      <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center">
+        <div className="text-sm text-gray-400 mb-4 md:mb-0">
+          © 2025 demo-funnel. All rights reserved.
+        </div>
+        <div className="flex space-x-6">
+          <a
+            href="#"
+            className="text-gray-400 hover:text-[#5046E4] transition-colors"
+          >
+            이용약관
+          </a>
+          <a
+            href="#"
+            className="text-gray-400 hover:text-[#5046E4] transition-colors"
+          >
+            개인정보 보호
+          </a>
+          <a
+            href="#"
+            className="text-gray-400 hover:text-[#5046E4] transition-colors"
+          >
+            문의하기
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+} 

--- a/components/class/ClassPage.tsx
+++ b/components/class/ClassPage.tsx
@@ -7,6 +7,7 @@ import AssignmentSubmissionSection from "@/components/class/AssignmentSubmission
 import DailyLectureSection from "@/components/class/DailyLectureSection";
 import RefundRequestButton from "@/components/class/RefundRequestButton";
 import { Loader2 } from "lucide-react";
+import ClassFooter from './ClassFooter';
 
 interface ClassPageProps {
   currentChallengeId: number;
@@ -59,50 +60,22 @@ export default function ClassPage({
             />
           </div>
 
-          <div>
-            <div className="bg-gradient-to-br from-[#252A3C] to-[#2A2F45] rounded-xl overflow-hidden shadow-lg border border-gray-700/50">
-              <div className="transition-all duration-300 hover:brightness-105">
-                <DailyLectureSection lectures={lectures} />
-              </div>
-
-              <AssignmentSubmissionSection userInfo={user} />
-
-              <RefundRequestButton
-                isAllSubmitted={isAllSubmitted}
-                isRefundRequested={isRefundRequested}
-              />
+          <div className="bg-gradient-to-br from-[#252A3C] to-[#2A2F45] rounded-xl overflow-hidden shadow-lg border border-gray-700/50">
+            <div className="transition-all duration-300 hover:brightness-105">
+              <DailyLectureSection lectures={lectures} />
             </div>
+
+            <AssignmentSubmissionSection userInfo={user} />
+
+            <RefundRequestButton
+              isAllSubmitted={isAllSubmitted}
+              isRefundRequested={isRefundRequested}
+            />
           </div>
         </div>
       </div>
 
-      <footer className="container mx-auto px-4 py-8 mt-20 border-t border-gray-800/50">
-        <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center">
-          <div className="text-sm text-gray-400 mb-4 md:mb-0">
-            © 2025 demo-funnel. All rights reserved.
-          </div>
-          <div className="flex space-x-6">
-            <a
-              href="#"
-              className="text-gray-400 hover:text-[#5046E4] transition-colors"
-            >
-              이용약관
-            </a>
-            <a
-              href="#"
-              className="text-gray-400 hover:text-[#5046E4] transition-colors"
-            >
-              개인정보 보호
-            </a>
-            <a
-              href="#"
-              className="text-gray-400 hover:text-[#5046E4] transition-colors"
-            >
-              문의하기
-            </a>
-          </div>
-        </div>
-      </footer>
+      <ClassFooter />
     </div>
   );
 }

--- a/components/class/DailyLectureSection.tsx
+++ b/components/class/DailyLectureSection.tsx
@@ -83,7 +83,7 @@ export default function DailyLectureSection({
     setIsPlaying(false);
   };
 
-  const handleLockedClick = (title: string) => {
+  const handleLockedClick = () => {
     setIsLockedModalOpen(true);
   };
 

--- a/components/class/MainLecture.tsx
+++ b/components/class/MainLecture.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { Play, Pause, Bookmark, Share2 } from "lucide-react";
+import { Play, Pause } from "lucide-react";
 import { Button } from "@/components/common/button";
 import { getVideoThumbnailUrl, getYouTubeEmbedUrl } from "@/utils/youtube";
 

--- a/hooks/class/useClassPage.ts
+++ b/hooks/class/useClassPage.ts
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { useUser } from "@/hooks/auth/useUser";
+import { getLecturesByChallenge } from "@/apis/lectures";
+import { getUserChallenges } from "@/apis/challenges";
+import { LectureWithSequence } from "@/types/lecture";
+import { useSelectedLectureStore } from "@/lib/store/useSelectedLectureStore";
+import { useRefundStatus } from "@/hooks/class/useRefundStatus";
+
+interface UseClassPageProps {
+  currentChallengeId: number;
+  initialLecture: LectureWithSequence;
+}
+
+export function useClassPage({ currentChallengeId, initialLecture }: UseClassPageProps) {
+  const router = useRouter();
+  const { data: user, isLoading: isLoadingUser } = useUser();
+  const setSelectedLecture = useSelectedLectureStore((s) => s.setSelectedLecture);
+
+  // 로그인에서 저장한 쿼리 캐시의 챌린지 목록 사용
+  const { data: challengeList = [] } = useQuery({
+    queryKey: ["challenge-list", user?.id],
+    queryFn: async () => {
+      if (!user?.id) return [];
+      const data = await getUserChallenges(user.id);
+      return data;
+    },
+    enabled: !isLoadingUser && !!user?.id,
+    staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
+  });
+
+  // 챌린지의 강의 조회
+  const { data: lectures = [], isLoading: isLecturesLoading } = useQuery<
+    LectureWithSequence[]
+  >({
+    queryKey: ["challenge-lectures", currentChallengeId],
+    queryFn: async () => {
+      const data = await getLecturesByChallenge(currentChallengeId);
+      return data;
+    },
+    enabled: !isLoadingUser && !!user?.id,
+    staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
+  });
+
+  const challengeLectures = lectures.map((lecture) => ({
+    id: lecture.challenge_lecture_id,
+    lecture_id: lecture.id,
+  }));
+
+  const { isAllSubmitted, isRefundRequested } = useRefundStatus(
+    user?.id,
+    challengeLectures,
+  );
+
+  // 사용자가 없을 때 리디렉션
+  useEffect(() => {
+    if (!isLoadingUser && !user) {
+      router.push("/login");
+    }
+  }, [isLoadingUser, user, router]);
+
+  // 초기 강의 설정
+  useEffect(() => {
+    setSelectedLecture(initialLecture);
+  }, [initialLecture, setSelectedLecture]);
+
+  // 챌린지 변경 핸들러
+  const handleChallengeChange = (value: string) => {
+    router.replace(`/class/${value}`);
+  };
+
+  const isLoading = isLoadingUser || !user || isLecturesLoading;
+
+  return {
+    user,
+    challengeList,
+    lectures,
+    isAllSubmitted,
+    isRefundRequested,
+    isLoading,
+    handleChallengeChange,
+  };
+} 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #180

## 📝작업 내용

> 서비스 페이지 UI/비지니스 로직 분리 및 불필요한 로직 제거, 파비콘 경로 수정

<!-- ### 스크린샷 (선택) -->

## 💬리뷰 요구사항 

문제: `/class/[challengeId]` 경로에서 브라우저의 파비콘 요청(`icon.ico`)이 잘못된 파라미터로 처리되어 500 에러가 발생 (터미널에서 확인)
해결: `page.tsx`에서 ID 유효성을 검사하고 `layout.tsx`에 파비콘 절대 경로를 명시
