### PR TITLE
fix: 환급신청 버튼 반응형 UI 수정

### DIFF
--- a/components/class/RefundRequestButton.tsx
+++ b/components/class/RefundRequestButton.tsx
@@ -58,7 +58,7 @@ export default function RefundRequestButton({
       <Button
         onClick={() => setIsOpen(true)}
         disabled={!isAllSubmitted || isRefundRequested}
-        className="absolute right-6 w-1/6 bg-[#5046E4] hover:bg-[#4339D1] text-white font-semibold py-3 px-6 rounded-lg transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-500 disabled:hover:bg-gray-500"
+        className="absolute right-6 w-auto min-w-[120px] sm:w-1/6 bg-[#5046E4] hover:bg-[#4339D1] text-white font-semibold py-3 px-6 rounded-lg transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-500 disabled:hover:bg-gray-500 text-sm sm:text-base whitespace-nowrap"
       >
         {isRefundRequested ? "환급신청 완료" : "환급신청 하기"}
       </Button>


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
- 사용자 페이지 환급신청 버튼 반응형 UI 수정했습니다.
  > 기존에 모바일뷰의 경우 버튼 텍스트가 버튼을 벗어나는 이슈가 있어 수정했습니다.

### 스크린샷 (선택)
- 수정 전
<img width="455" alt="스크린샷 2025-06-23 오후 12 48 25" src="https://github.com/user-attachments/assets/4fc5f5c7-5930-461e-a4b8-903e5b2b38d9" />

- 수정 후
<img width="431" alt="스크린샷 2025-06-23 오후 12 49 18" src="https://github.com/user-attachments/assets/22890002-2bd5-424e-af97-635c6f387027" />

## 💬리뷰 요구사항(선택)

> 
