### PR TITLE
fix: 환급 신청 모달 1대1 커피챗 필드 삭제

### DIFF
--- a/components/class/RefundRequestForm.tsx
+++ b/components/class/RefundRequestForm.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/common/button";
 import { Input } from "@/components/common/input";
 import { Label } from "@/components/common/label";
 import { Textarea } from "@/components/common/textarea";
-import { Switch } from "@/components/common/switch";
 import { useUser } from "@/hooks/auth/useUser";
 import { updateRefundRequestStatus } from "@/apis/users";
 import { useQueryClient } from "@tanstack/react-query";
@@ -197,35 +196,6 @@ export default function RefundRequestForm({
             />
           </div>
         </div>
-        <div className="flex items-center space-x-2">
-          <Switch
-            id="wantsCoffeeChat"
-            checked={formData.wantCoffeeChat}
-            onCheckedChange={(checked) =>
-              setFormData({ ...formData, wantCoffeeChat: checked })
-            }
-            className="data-[state=checked]:bg-[#5046E4] bg-gray-700"
-          />
-          <Label htmlFor="wantsCoffeeChat">1대1 커피챗 희망 여부</Label>
-          <span className="text-red-500 ml-1">*</span>
-        </div>
-
-        {formData.wantCoffeeChat && (
-          <div>
-            <Label htmlFor="coffeeChatContent">
-              1대1 커피챗 다루고 싶은 내용
-            </Label>
-            <Textarea
-              id="coffeeChatContent"
-              value={formData.coffeeChatContent}
-              onChange={(e) =>
-                setFormData({ ...formData, coffeeChatContent: e.target.value })
-              }
-              placeholder="커피챗에서 다루고 싶은 주제나 질문을 작성해주세요"
-              className="bg-[#1C1F2B] border-gray-700"
-            />
-          </div>
-        )}
 
         <div>
           <Label htmlFor="futureContent">


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
- 환급 신청 모달 1대1 커피챗 관련된 필드 삭제했습니다.

### 스크린샷 (선택)
- 수정 전
<img width="414" height="502" alt="image" src="https://github.com/user-attachments/assets/dea3c3c0-ff36-4f20-b355-4940c1b1ae41" />

- 수정 후
<img width="461" height="521" alt="스크린샷 2025-07-11 오후 8 14 33" src="https://github.com/user-attachments/assets/9c99aa0b-0254-41ad-98bc-a833b9cd6bce" />

## 💬리뷰 요구사항(선택)

>
